### PR TITLE
getWorkspacePackageDirs returns paths joined against workspace root

### DIFF
--- a/packages/utils/src/getPackageNameToDir.ts
+++ b/packages/utils/src/getPackageNameToDir.ts
@@ -10,10 +10,15 @@ import { getWorkspacePackageDirs } from "./getWorkspacePackageDirs";
 import { PackageJson } from "./PackageJson";
 import { readJson } from "./readJson";
 
-export function getPackageNameToDir(workspaceDir: string) {
+/**
+ * returns a map of package names to their directories in the workspace.
+ * if `resolvePaths` is true, the returned directory names are absolute paths
+ * resolved against the `workspaceDir`.
+ */
+export function getPackageNameToDir(workspaceDir: string, resolvePaths: boolean = false) {
   const ret = new Map<string, string>();
 
-  for (const packageDir of getWorkspacePackageDirs(workspaceDir)) {
+  for (const packageDir of getWorkspacePackageDirs(workspaceDir, resolvePaths)) {
     const packagePath = pathJoin(packageDir, "package.json");
     const { name } = readJson(packagePath) as PackageJson;
     if (name === undefined) {

--- a/packages/utils/src/getWorkspacePackageDirs.ts
+++ b/packages/utils/src/getWorkspacePackageDirs.ts
@@ -7,11 +7,11 @@
 
 import { existsSync } from "fs";
 import glob from "glob";
-import { join as pathJoin } from "path";
+import { join as pathJoin, resolve as pathResolve } from "path";
 import { PackageJson } from "./PackageJson";
 import { readJson } from "./readJson";
 
-export function getWorkspacePackageDirs(workspaceDir: string) {
+export function getWorkspacePackageDirs(workspaceDir: string, resolvePaths: boolean = false) {
   const ret: string[] = [];
 
   const packageJson: PackageJson = readJson(pathJoin(workspaceDir, "package.json"));
@@ -29,7 +29,11 @@ export function getWorkspacePackageDirs(workspaceDir: string) {
       const packageJsonPath = pathJoin(workspaceDir, packagePath, "package.json");
 
       if (existsSync(packageJsonPath)) {
-        ret.push(packagePath);
+        if (resolvePaths === true) {
+          ret.push(pathResolve(pathJoin(workspaceDir, packagePath)));
+        } else {
+          ret.push(packagePath);
+        }
       }
     }
   }


### PR DESCRIPTION
this means that if you pass an absolute path as workspaceDir, individual
package dirs will also be absolute paths, which is helpful if calling
getWorkspacePackageDirs from other working directories.