### PR TITLE
Rename @monorepolint/cli to monorepolint.

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "monorepolint",
+  "name": "@monorepolint/all",
   "version": "0.4.0",
   "license": "MIT",
+  "private": true,
   "scripts": {
     "clean": "rm -rf build lib node_modules *.tgz",
     "compile:typescript": "../../node_modules/.bin/tsc",
@@ -13,7 +14,7 @@
     "test": "../../node_modules/.bin/jest --colors --passWithNoTests"
   },
   "dependencies": {
-    "@monorepolint/cli": "^0.4.0",
+    "monorepolint": "^0.4.0",
     "@monorepolint/core": "^0.4.0",
     "@monorepolint/rules": "^0.4.0",
     "@monorepolint/utils": "^0.4.0"

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -14,10 +14,10 @@
     "test": "../../node_modules/.bin/jest --colors --passWithNoTests"
   },
   "dependencies": {
-    "monorepolint": "^0.4.0",
     "@monorepolint/core": "^0.4.0",
     "@monorepolint/rules": "^0.4.0",
-    "@monorepolint/utils": "^0.4.0"
+    "@monorepolint/utils": "^0.4.0",
+    "monorepolint": "^0.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/all/tsconfig.json
+++ b/packages/all/tsconfig.json
@@ -6,9 +6,6 @@
   },
   "references": [
     {
-      "path": "../cli"
-    },
-    {
       "path": "../core"
     },
     {
@@ -16,6 +13,9 @@
     },
     {
       "path": "../utils"
+    },
+    {
+      "path": "../cli"
     }
   ]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@monorepolint/cli",
+  "name": "monorepolint",
   "version": "0.4.0",
   "author": "Eric L Anderson (https://github.com/ericanderson)",
   "contributors": [


### PR DESCRIPTION
This makes it so that `packages/all` is purely a local build sink.
Instead, `packages/cli` is now used as the public facing package. The
reason being this allows for the actual binary for the cli to be in a
predictable location regardless of the npm client being used.

Previously, there was a difference of location when using yarn vs yarn
workspaces. The latter would always hoist the binary while the former
did not.