### PR TITLE
Allow banned dependencies to be a glob instead of an exact string match

### DIFF
--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -22,10 +22,12 @@
     "@monorepolint/core": "^0.4.0",
     "@monorepolint/utils": "^0.4.0",
     "jest-diff": "^23.6.0",
+    "minimatch": "^3.0.4",
     "runtypes": "^4.0.0"
   },
   "devDependencies": {
-    "@types/jest-diff": "^20.0.0"
+    "@types/jest-diff": "^20.0.0",
+    "@types/minimatch": "^3.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rules/src/bannedDependencies.ts
+++ b/packages/rules/src/bannedDependencies.ts
@@ -8,6 +8,7 @@
 import { Context, RuleModule } from "@monorepolint/core";
 import { writeJson } from "@monorepolint/utils";
 import diff from "jest-diff";
+import minimatch from "minimatch";
 import * as r from "runtypes";
 
 const Options = r.Record({
@@ -45,9 +46,11 @@ function checkBanned(
 
   const expectedDependencies: Record<string, string> = {};
 
-  for (const key of Object.keys(dependencies)) {
-    if (bannedDependencies.indexOf(key) < 0) {
-      expectedDependencies[key] = dependencies[key];
+  for (const dependency of Object.keys(dependencies)) {
+    for (const bannedDependency of bannedDependencies) {
+      if (!minimatch(dependency, bannedDependency)) {
+        expectedDependencies[dependency] = dependencies[dependency];
+      }
     }
   }
 


### PR DESCRIPTION
Hey @ericanderson , 

I'd like to ban a bunch of similar dependencies via globs! Can MRL support that? 
