### PR TITLE
Allow multiple options for scripts

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -192,7 +192,18 @@ module.exports = {
       options: {
         scripts: {
           "clean": "rm -rf build lib node_modules *.tgz",
-          "compile": "../../node_modules/.bin/tsc"
+          "compile": "../../node_modules/.bin/tsc",
+          "goodbye": {
+            options: [undefined],
+            fixValue: undefined, // fix removes value
+          },
+          "any-of-these-no-auto-fix": {
+            options: ["a", "b", "c"],
+          },
+          "any-of-these-auto-fix-to-c": {
+            options: ["a", "b", "c"],
+            fixValue: "c"
+          }
         }
       }
     }

--- a/packages/core/src/Config.ts
+++ b/packages/core/src/Config.ts
@@ -35,6 +35,7 @@ export interface Options {
   readonly verbose?: boolean;
   readonly fix?: boolean;
   readonly paths?: ReadonlyArray<string>;
+  readonly silent?: boolean;
 }
 
 export type Checker<T extends Runtype> = (context: Context, args: r.Static<T>) => void;

--- a/packages/core/src/PackageContext.ts
+++ b/packages/core/src/PackageContext.ts
@@ -115,16 +115,25 @@ export class PackageContext implements Context {
   }
 
   private print(str: string, depth: number = this.depth + 1) {
+    if (this.resolvedConfig.silent) {
+      return;
+    }
     // tslint:disable-next-line:no-console
     console.log(this.getMessage(str, depth));
   }
 
   private printWarning(str: string, depth: number = this.depth + 1) {
+    if (this.resolvedConfig.silent) {
+      return;
+    }
     // tslint:disable-next-line:no-console
     console.warn(this.getMessage(str, depth));
   }
 
   private printError(str: string, depth: number = this.depth + 1) {
+    if (this.resolvedConfig.silent) {
+      return;
+    }
     // tslint:disable-next-line:no-console
     console.error(this.getMessage(str, depth));
   }
@@ -134,6 +143,9 @@ export class PackageContext implements Context {
   }
 
   private printName() {
+    if (this.resolvedConfig.silent) {
+      return;
+    }
     if (this.printedName) {
       return;
     }

--- a/packages/rules/src/__tests__/packageOrder.spec.ts
+++ b/packages/rules/src/__tests__/packageOrder.spec.ts
@@ -95,6 +95,7 @@ describe("expectPackageOrder", () => {
       rules: [],
       fix: true,
       verbose: false,
+      silent: true,
     });
     const spy = jest.spyOn(context, "addError");
 

--- a/packages/rules/src/__tests__/packageScript.spec.ts
+++ b/packages/rules/src/__tests__/packageScript.spec.ts
@@ -176,5 +176,25 @@ describe("expectPackageScript", () => {
         foo: "a",
       });
     });
+
+    it("can fix to empty", () => {
+      mockFiles.set("package.json", PACKAGE_WITH_SCRIPTS);
+
+      packageScript.check(context, {
+        scripts: {
+          [SCRIPT_NAME]: {
+            options: ["a", undefined],
+            fixValue: undefined,
+          },
+        },
+      });
+
+      const errors = spy.mock.calls;
+
+      expect(errors.length).toBe(1);
+      expect(errors[0][0].fixer).toBeDefined();
+
+      expect(JSON.parse(mockFiles.get("package.json")!).scripts).toEqual({});
+    });
   });
 });

--- a/packages/rules/src/__tests__/packageScript.spec.ts
+++ b/packages/rules/src/__tests__/packageScript.spec.ts
@@ -14,14 +14,11 @@ const mockFiles: Map<string, string> = createMockFiles();
 import { Failure, PackageContext } from "@monorepolint/core";
 import { packageScript } from "../packageScript";
 
-const PACKAGE_WITHOUT_SCRIPTS =
-  JSON.stringify(
-    {
-      name: "package-without-scripts",
-    },
-    undefined,
-    2
-  ) + "\n";
+const json = (a: unknown) => JSON.stringify(a, undefined, 2) + "\n";
+
+const PACKAGE_WITHOUT_SCRIPTS = json({
+  name: "package-without-scripts",
+});
 
 const MISSING_SCRIPT_NAME = "missing";
 const MISSING_SCRIPT_VALUE = "missing value";
@@ -29,17 +26,12 @@ const MISSING_SCRIPT_VALUE = "missing value";
 const SCRIPT_NAME = "exists";
 const SCRIPT_VALUE = "exists value";
 
-const PACKAGE_WITH_SCRIPTS =
-  JSON.stringify(
-    {
-      name: "package-with-scripts",
-      scripts: {
-        [SCRIPT_NAME]: SCRIPT_VALUE,
-      },
-    },
-    undefined,
-    2
-  ) + "\n";
+const PACKAGE_WITH_SCRIPTS = json({
+  name: "package-with-scripts",
+  scripts: {
+    [SCRIPT_NAME]: SCRIPT_VALUE,
+  },
+});
 
 describe("expectPackageScript", () => {
   afterEach(() => {
@@ -51,6 +43,7 @@ describe("expectPackageScript", () => {
       rules: [],
       fix: false,
       verbose: false,
+      silent: true,
     });
 
     const spy = jest.spyOn(context, "addError");
@@ -82,6 +75,7 @@ describe("expectPackageScript", () => {
       rules: [],
       fix: true,
       verbose: false,
+      silent: true,
     });
     const spy = jest.spyOn(context, "addError");
 
@@ -122,7 +116,7 @@ describe("expectPackageScript", () => {
       const failure: Failure = spy.mock.calls[0][0];
       expect(failure.file).toBe("package.json");
       expect(failure.fixer).not.toBeUndefined();
-      expect(failure.message).toBe(`Expected standardized script entry for '${MISSING_SCRIPT_NAME}'`);
+      expect(failure.message).toMatch(`Expected standardized script entry for '${MISSING_SCRIPT_NAME}'`);
 
       expect(JSON.parse(mockFiles.get("package.json")!).scripts[MISSING_SCRIPT_NAME]).toEqual(MISSING_SCRIPT_VALUE);
     });
@@ -140,6 +134,46 @@ describe("expectPackageScript", () => {
 
       expect(JSON.parse(mockFiles.get("package.json")!).scripts).toEqual({
         [SCRIPT_NAME]: SCRIPT_VALUE,
+      });
+    });
+
+    it("errors if long form is used and no value matches and there is no fixValue", () => {
+      mockFiles.set("package.json", PACKAGE_WITH_SCRIPTS);
+
+      packageScript.check(context, {
+        scripts: {
+          foo: {
+            options: ["a", "b"],
+          },
+        },
+      });
+
+      const errors = spy.mock.calls;
+
+      expect(errors.length).toBe(1);
+      expect(errors[0][0].fixer).toBeUndefined();
+    });
+
+    it("uses the fixValue for fixing if provided", () => {
+      mockFiles.set("package.json", PACKAGE_WITH_SCRIPTS);
+
+      packageScript.check(context, {
+        scripts: {
+          foo: {
+            options: ["a", "b"],
+            fixValue: "a",
+          },
+        },
+      });
+
+      const errors = spy.mock.calls;
+
+      expect(errors.length).toBe(1);
+      expect(errors[0][0].fixer).toBeDefined();
+
+      expect(JSON.parse(mockFiles.get("package.json")!).scripts).toEqual({
+        [SCRIPT_NAME]: SCRIPT_VALUE,
+        foo: "a",
       });
     });
   });

--- a/packages/rules/src/__tests__/packageScript.spec.ts
+++ b/packages/rules/src/__tests__/packageScript.spec.ts
@@ -196,5 +196,25 @@ describe("expectPackageScript", () => {
 
       expect(JSON.parse(mockFiles.get("package.json")!).scripts).toEqual({});
     });
+
+    it("can allow only empty", () => {
+      mockFiles.set("package.json", PACKAGE_WITH_SCRIPTS);
+
+      packageScript.check(context, {
+        scripts: {
+          [SCRIPT_NAME]: {
+            options: [undefined],
+            fixValue: undefined,
+          },
+        },
+      });
+
+      const errors = spy.mock.calls;
+
+      expect(errors.length).toBe(1);
+      expect(errors[0][0].fixer).toBeDefined();
+
+      expect(JSON.parse(mockFiles.get("package.json")!).scripts).toEqual({});
+    });
   });
 });

--- a/packages/rules/src/packageScript.ts
+++ b/packages/rules/src/packageScript.ts
@@ -11,7 +11,20 @@ import diff from "jest-diff";
 import * as r from "runtypes";
 
 export const Options = r.Record({
-  scripts: r.Dictionary(r.String), // string => string
+  scripts: r.Dictionary(
+    r.Union(
+      r.String,
+      r
+        .Record({
+          options: r.Array(r.String.Or(r.Undefined)),
+        })
+        .And(
+          r.Partial({
+            fixValue: r.Union(r.String, r.Literal(false)),
+          })
+        )
+    )
+  ), // string => string
 });
 
 export type Options = r.Static<typeof Options>;
@@ -35,17 +48,47 @@ export const packageScript = {
       return;
     }
     for (const [name, value] of Object.entries(options.scripts)) {
-      if (packageJson.scripts[name] !== value) {
-        context.addError({
-          file: context.getPackageJsonPath(),
-          message: `Expected standardized script entry for '${name}'`,
-          longMessage: diff(value + "\n", (packageJson.scripts[name] || "") + "\n"),
-          fixer: () => {
+      const allowedValues = new Set<string>();
+      let fixValue: string | undefined | false;
+      let allowEmpty = false;
+
+      if (typeof value === "string") {
+        allowedValues.add(value);
+        fixValue = value;
+      } else {
+        for (const q of value.options) {
+          if (q === undefined) {
+            allowEmpty = true;
+          } else {
+            allowedValues.add(q);
+          }
+        }
+        fixValue = value.fixValue;
+      }
+
+      const actualValue = packageJson.scripts[name];
+
+      if (!allowedValues.has(actualValue) && !(allowEmpty === true && actualValue === undefined)) {
+        let fixer;
+
+        if (fixValue !== false && fixValue !== undefined) {
+          const q: string = fixValue;
+          fixer = () => {
             mutateJson<PackageJson>(context.getPackageJsonPath(), input => {
-              input.scripts![name] = value;
+              input.scripts![name] = q;
               return input;
             });
-          },
+          };
+        }
+        context.addError({
+          file: context.getPackageJsonPath(),
+          message: `Expected standardized script entry for '${name}'. Valid options: ${Array.from(
+            allowedValues.values()
+          )
+            .map(a => `'${a}'`)
+            .join(", ")}`,
+          longMessage: diff(value + "\n", (packageJson.scripts[name] || "") + "\n"),
+          fixer,
         });
       }
     }

--- a/packages/rules/src/packageScript.ts
+++ b/packages/rules/src/packageScript.ts
@@ -90,7 +90,7 @@ export const packageScript = {
           message: `Expected standardized script entry for '${name}'. Valid options: ${Array.from(
             allowedValues.values()
           )
-            .map(a => (a === undefined ? "(empty}" : `'${a}'`))
+            .map(a => (a === undefined ? "(empty)" : `'${a}'`))
             .join(", ")}`,
           longMessage: diff(value + "\n", (packageJson.scripts[name] || "") + "\n"),
           fixer,


### PR DESCRIPTION
You can now do 

```ts
":package-script": {
  options: {
    scripts: {
      "foo": {
        options: ["a", "b"],
        fixValue: "a",
      }
      "bar": {
        options: ["a", undefined],
        fixValue: undefined,
      }
      "baz": {
        options: ["a", "b"], // no fixer
      }
    }
  }
}
```