### PR TITLE
Fix object comparison for packageEntry rule

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,161 +1,160 @@
 module.exports = {
     clearMocks: true,
     coverageDirectory: "coverage",
-  
+
     coveragePathIgnorePatterns: [
       "/node_modules/"
     ],
-  
+
     coverageReporters: [
       "json",
       "text",
       "lcov",
       "clover"
     ],
-  
+
     // An object that configures minimum threshold enforcement for coverage results
     // coverageThreshold: null,
-  
+
     // Make calling deprecated APIs throw helpful error messages
     // errorOnDeprecated: false,
-  
+
     // Force coverage collection from ignored files usin a array of glob patterns
     // forceCoverageMatch: [],
-  
+
     // A path to a module which exports an async function that is triggered once before all test suites
     // globalSetup: null,
-  
+
     // A path to a module which exports an async function that is triggered once after all test suites
     // globalTeardown: null,
-  
+
     // A set of global variables that need to be available in all test environments
     globals: {
       "ts-jest": {
         "tsConfig": "./tsconfig.json"
       }
     },
-  
+
     // An array of directory names to be searched recursively up from the requiring module's location
     // moduleDirectories: [
     //   "node_modules"
     // ],
-  
+
     // An array of file extensions your modules use
     moduleFileExtensions: [
       "ts",
       "tsx",
       "js"
     ],
-  
+
     // A map from regular expressions to module names that allow to stub out resources with a single module
     // moduleNameMapper: {},
-  
+
     // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
     // modulePathIgnorePatterns: [],
-  
+
     // Activates notifications for test results
     notify: true,
-  
+
     // An enum that specifies notification mode. Requires { notify: true }
     // notifyMode: "always",
-  
+
     // A preset that is used as a base for Jest's configuration
     // preset: null,
-  
+
     // Run tests from one or more projects
     // projects: null,
-  
+
     // Use this configuration option to add custom reporters to Jest
     // reporters: undefined,
-  
+
     // Automatically reset mock state between every test
     // resetMocks: false,
-  
+
     // Reset the module registry before running each individual test
     // resetModules: false,
-  
+
     // A path to a custom resolver
     // resolver: null,
-  
+
     // Automatically restore mock state between every test
     // restoreMocks: false,
-  
+
     // The root directory that Jest should scan for tests and modules within
     // rootDir: null,
-  
+
     // A list of paths to directories that Jest should use to search for files in
     // roots: [
     //   "<rootDir>"
     // ],
-  
+
     // Allows you to use a custom runner instead of Jest's default test runner
     // runner: "jest-runner",
-  
+
     // The paths to modules that run some code to configure or set up the testing environment before each test
     // setupFiles: [],
-  
+
     // The path to a module that runs some code to configure or set up the testing framework before each test
     // setupTestFrameworkScriptFile: null,
-  
+
     // A list of paths to snapshot serializer modules Jest should use for snapshot testing
     // snapshotSerializers: [],
-  
+
     // The test environment that will be used for testing
     testEnvironment: "node",
-  
+
     // Options that will be passed to the testEnvironment
     // testEnvironmentOptions: {},
-  
+
     // Adds a location field to test results
     // testLocationInResults: false,
-  
+
     // The glob patterns Jest uses to detect test files
     testMatch: [
-      "src/**/__tests__/*.spec.+(ts|tsx|js)"
+      "<rootDir>/src/**/__tests__/*.spec.+(ts|tsx|js)"
     ],
-  
+
     // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
     testPathIgnorePatterns: [
       "/node_modules/",
       "/build",
       "/lib"
     ],
-  
+
     // The regexp pattern Jest uses to detect test files
     // testRegex: "",
-  
+
     // This option allows the use of a custom results processor
     // testResultsProcessor: null,
-  
+
     // This option allows use of a custom test runner
     // testRunner: "jasmine2",
-  
+
     // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
     // testURL: "http://localhost",
-  
+
     // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
     // timers: "real",
-  
+
     // A map from regular expressions to paths to transformers
     transform: {
       "^.+\\.(ts|tsx)$": "ts-jest"
     },
-  
+
     // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
     // transformIgnorePatterns: [
     //   "/node_modules/"
     // ],
-  
+
     // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
     // unmockedModulePathPatterns: undefined,
-  
+
     // Indicates whether each individual test should be reported during the run
     verbose: true,
-  
+
     // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
     // watchPathIgnorePatterns: [],
-  
+
     // Whether to use watchman for file crawling
     // watchman: true,
   };
-  

--- a/packages/rules/src/__tests__/packageEntry.spec.ts
+++ b/packages/rules/src/__tests__/packageEntry.spec.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright 2019 Palantir Technologies, Inc.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ */
+
+// tslint:disable:no-console
+import { createMockFiles } from "./utils";
+
+// done first since this also mocks 'fs'
+const mockFiles: Map<string, string> = createMockFiles();
+
+import { Failure, PackageContext } from "@monorepolint/core";
+import { packageEntry } from "../packageEntry";
+
+const PACKAGE_MISSING_ENTRY =
+  JSON.stringify(
+    {
+      name: "package",
+      version: {},
+      scripts: {},
+      dependencies: {},
+    },
+    undefined,
+    2
+  ) + "\n";
+
+const PACKAGE_LICENSE =
+  JSON.stringify(
+    {
+      name: "package",
+      version: {},
+      scripts: {},
+      dependencies: {},
+      license: "UNLICENSED",
+    },
+    undefined,
+    2
+  ) + "\n";
+
+const PACKAGE_REPOSITORY =
+  JSON.stringify(
+    {
+      name: "package",
+      version: {},
+      scripts: {},
+      dependencies: {},
+      repository: {
+        type: "git",
+        url: "https://github.com:foo/foo",
+      },
+    },
+    undefined,
+    2
+  ) + "\n";
+
+describe("expectPackageEntries", () => {
+  afterEach(() => {
+    mockFiles.clear();
+  });
+
+  describe("fix: true", () => {
+    const context = new PackageContext(".", {
+      rules: [],
+      fix: true,
+      verbose: false,
+      silent: true,
+    });
+    const spy = jest.spyOn(context, "addError");
+
+    afterEach(() => {
+      spy.mockClear();
+    });
+
+    it("fixes missing entries", () => {
+      mockFiles.set("package.json", PACKAGE_MISSING_ENTRY);
+
+      packageEntry.check(context, {
+        entries: {
+          license: "UNLICENSED",
+        },
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      const failure: Failure = spy.mock.calls[0][0];
+      expect(failure.file).toBe("package.json");
+      expect(failure.fixer).not.toBeUndefined();
+      expect(failure.message).toBe("Expected standardized entry for 'license'");
+
+      expect(mockFiles.get("package.json")).toEqual(PACKAGE_LICENSE);
+    });
+
+    it("fixes missing nested entries", () => {
+      mockFiles.set("package.json", PACKAGE_MISSING_ENTRY);
+
+      packageEntry.check(context, {
+        entries: {
+          repository: {
+            type: "git",
+            url: "https://github.com:foo/foo",
+          },
+        },
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      const failure: Failure = spy.mock.calls[0][0];
+      expect(failure.file).toBe("package.json");
+      expect(failure.fixer).not.toBeUndefined();
+      expect(failure.message).toBe("Expected standardized entry for 'repository'");
+
+      expect(mockFiles.get("package.json")).toEqual(PACKAGE_REPOSITORY);
+    });
+
+    it("doesn't error for nested entries that are defined", () => {
+      mockFiles.set("package.json", PACKAGE_REPOSITORY);
+
+      packageEntry.check(context, {
+        entries: {
+          repository: {
+            type: "git",
+            url: "https://github.com:foo/foo",
+          },
+        },
+      });
+
+      expect(spy).toHaveBeenCalledTimes(0);
+      expect(mockFiles.get("package.json")).toEqual(PACKAGE_REPOSITORY);
+    });
+  });
+});

--- a/packages/rules/src/packageEntry.ts
+++ b/packages/rules/src/packageEntry.ts
@@ -23,11 +23,15 @@ export const packageEntry = {
     for (const key of Object.keys(options.entries)) {
       const value = options.entries[key];
 
-      if (packageJson[key] !== value) {
+      const entryDiff = diff(JSON.stringify(value) + "\n", (JSON.stringify(packageJson[key]) || "") + "\n");
+      if (
+        (typeof value !== "object" && value !== packageJson[key]) ||
+        (entryDiff == null || !entryDiff.includes("Compared values have no visual difference"))
+      ) {
         context.addError({
           file: context.getPackageJsonPath(),
           message: `Expected standardized entry for '${key}'`,
-          longMessage: diff(value + "\n", (packageJson[key] || "") + "\n"),
+          longMessage: entryDiff,
           fixer: () => {
             mutateJson<PackageJson>(context.getPackageJsonPath(), input => {
               input[key] = value;


### PR DESCRIPTION
I noticed that if I tried to enforce a nested object in package entry, it would fail the check but pass with `--fix`:

```
":package-entry": [
            {
                options: {
                    entries: {
                        "repository": {
                            "type": "git",
                            "url": "https://github.com/foo/foo.git"
                        }
                    }
                }
            }
]
```

There's probably a cleaner way to do this comparison with lodash, but didn't know if y'all were avoiding the dep.

Additionally, I noticed that when running `yarn test` from root no tests were actually running, so I tweaked jest.config.base.js to fix that