### PR TITLE
Added option to exclude some projects from tsconfig project references

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "lint-staged": {
     "packages/*/src/**/*.{ts,tsx}": [
-      "tslint -c tslint.json --fix",
       "prettier --write",
+      "tslint -c tslint.json --fix",
       "git add"
     ]
   },

--- a/packages/rules/src/__tests__/consistentDependencies.spec.ts
+++ b/packages/rules/src/__tests__/consistentDependencies.spec.ts
@@ -73,9 +73,18 @@ describe("consistentDependencies", () => {
     function addFile(filePath: string, content: string) {
       const dirPath = path.resolve(dir.name, path.dirname(filePath));
       const resolvedFilePath = path.resolve(dir.name, filePath);
-      if (!existsSync(dirPath)) {
-        mkdirSync(dirPath, { recursive: true });
+
+      // node < 10 doesn't support mkdirSync w/ recursive: true
+      // so we manually do it instead
+      const dirSegments = dirPath.split(path.sep);
+      for (let i = 2; i <= dirSegments.length; i++) {
+        // we skip the empty segment
+        const curDirPath = dirSegments.slice(0, i).join(path.sep);
+        if (!existsSync(curDirPath)) {
+          mkdirSync(curDirPath);
+        }
       }
+
       writeFileSync(resolvedFilePath, content);
     }
 

--- a/packages/rules/src/__tests__/consistentDependencies.spec.ts
+++ b/packages/rules/src/__tests__/consistentDependencies.spec.ts
@@ -5,7 +5,7 @@
  *
  */
 import { WorkspaceContext } from "@monorepolint/core";
-import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import * as path from "path";
 import * as tmp from "tmp";
 import { consistentDependencies } from "../consistentDependencies";
@@ -73,7 +73,9 @@ describe("consistentDependencies", () => {
     function addFile(filePath: string, content: string) {
       const dirPath = path.resolve(dir.name, path.dirname(filePath));
       const resolvedFilePath = path.resolve(dir.name, filePath);
-      mkdirSync(dirPath, { recursive: true });
+      if (!existsSync(dirPath)) {
+        mkdirSync(dirPath, { recursive: true });
+      }
       writeFileSync(resolvedFilePath, content);
     }
 


### PR DESCRIPTION
This adds an option to ignore certain packages in your monorepo from tsconfig project references. A case in which this may be useful is if your monorepo has a package for build tooling that uses a separate build process than tsc (babel or ts-node).

Additionally, this fixes the node 8 test failure on master: [link](https://circleci.com/gh/monorepolint/monorepolint/799?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)