### PR TITLE
Fixed sort order for key 'description'

### DIFF
--- a/packages/rules/src/packageOrder.ts
+++ b/packages/rules/src/packageOrder.ts
@@ -23,6 +23,7 @@ type Options = r.Static<typeof Options>;
 const defaultKeyOrder = [
   "name",
   "version",
+  "description",
   "author",
   "contributors",
   "url",


### PR DESCRIPTION
blocked on the circle fix in #80 