### PR TITLE
Creating missing parent directory first for fileContents rule

### DIFF
--- a/packages/rules/src/__tests__/consistentDependencies.spec.ts
+++ b/packages/rules/src/__tests__/consistentDependencies.spec.ts
@@ -5,10 +5,11 @@
  *
  */
 import { WorkspaceContext } from "@monorepolint/core";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import * as path from "path";
 import * as tmp from "tmp";
 import { consistentDependencies } from "../consistentDependencies";
+import { makeDirectoryRecursively } from "../util/makeDirectory";
 import { jsonToString } from "./utils";
 
 const PACKAGE_ROOT = jsonToString({
@@ -72,17 +73,7 @@ describe("consistentDependencies", () => {
       const dirPath = path.resolve(dir.name, path.dirname(filePath));
       const resolvedFilePath = path.resolve(dir.name, filePath);
 
-      // node < 10 doesn't support mkdirSync w/ recursive: true
-      // so we manually do it instead
-      const dirSegments = dirPath.split(path.sep);
-      for (let i = 2; i <= dirSegments.length; i++) {
-        // we skip the empty segment
-        const curDirPath = dirSegments.slice(0, i).join(path.sep);
-        if (!existsSync(curDirPath)) {
-          mkdirSync(curDirPath);
-        }
-      }
-
+      makeDirectoryRecursively(dirPath);
       writeFileSync(resolvedFilePath, content);
     }
 

--- a/packages/rules/src/__tests__/fileContents.spec.ts
+++ b/packages/rules/src/__tests__/fileContents.spec.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright 2019 Palantir Technologies, Inc.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ */
+
+// tslint:disable:no-console
+import { createMockFiles } from "./utils";
+
+// done first since this also mocks 'fs'
+const mockFiles: Map<string, string> = createMockFiles();
+
+import { Failure, PackageContext } from "@monorepolint/core";
+import * as path from "path";
+import { fileContents } from "../fileContents";
+
+const EXPECTED_FOO_FILE = "hello world";
+
+describe("fileContents", () => {
+  afterEach(() => {
+    mockFiles.clear();
+  });
+
+  describe("fix: true", () => {
+    const context = new PackageContext(".", {
+      rules: [],
+      fix: true,
+      verbose: false,
+      silent: true,
+    });
+    const spy = jest.spyOn(context, "addError");
+
+    afterEach(() => {
+      spy.mockClear();
+    });
+
+    it("fixes missing file", () => {
+      mockFiles.set(path.resolve(context.getWorkspaceContext().packageDir, "foo-template.txt"), EXPECTED_FOO_FILE);
+
+      fileContents.check(context, {
+        file: "foo.txt",
+        templateFile: "foo-template.txt",
+        generator: undefined,
+        template: undefined,
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      const failure: Failure = spy.mock.calls[0][0];
+      expect(failure.file).toBe("foo.txt");
+      expect(failure.fixer).not.toBeUndefined();
+      expect(failure.message).toBe("Expect file contents to match");
+
+      expect(mockFiles.get("foo.txt")).toEqual(EXPECTED_FOO_FILE);
+    });
+
+    it("fixes missing nested file", () => {
+      mockFiles.set(
+        path.resolve(context.getWorkspaceContext().packageDir, "shared/foo-template.txt"),
+        EXPECTED_FOO_FILE
+      );
+
+      fileContents.check(context, {
+        file: "nested/foo.txt",
+        templateFile: "shared/foo-template.txt",
+        generator: undefined,
+        template: undefined,
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      const failure: Failure = spy.mock.calls[0][0];
+      expect(failure.file).toBe("nested/foo.txt");
+      expect(failure.fixer).not.toBeUndefined();
+      expect(failure.message).toBe("Expect file contents to match");
+
+      expect(mockFiles.get("nested")).not.toBeUndefined();
+      expect(mockFiles.get("nested/foo.txt")).toEqual(EXPECTED_FOO_FILE);
+    });
+  });
+});

--- a/packages/rules/src/__tests__/utils.ts
+++ b/packages/rules/src/__tests__/utils.ts
@@ -17,6 +17,14 @@ export function createMockFiles() {
     readFileSync: function readFileSync(filePath: string, _contentType: string) {
       return mockFiles.get(filePath);
     },
+
+    existsSync: function existsSync(filePath: string) {
+      return mockFiles.has(filePath);
+    },
+
+    mkdirSync: function mkdirSync(directoryPath: string) {
+      return mockFiles.set(directoryPath, "");
+    },
   }));
 
   return mockFiles;

--- a/packages/rules/src/fileContents.ts
+++ b/packages/rules/src/fileContents.ts
@@ -7,10 +7,11 @@
 
 import { Context } from "@monorepolint/core";
 import { RuleModule } from "@monorepolint/core";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import diff from "jest-diff";
 import * as path from "path";
 import * as r from "runtypes";
+import { makeDirectoryRecursively } from "./util/makeDirectory";
 
 const Options = r.Union(
   r.Record({
@@ -45,7 +46,6 @@ export const fileContents = {
 
     const pathExists = existsSync(fullPath);
     const actualContent = pathExists ? readFileSync(fullPath, "utf-8") : undefined;
-
     if (actualContent !== expectedContent) {
       context.addError({
         file: fullPath,
@@ -55,9 +55,7 @@ export const fileContents = {
           if (expectedContent === undefined && pathExists) {
             unlinkSync(fullPath);
           } else {
-            if (!existsSync(path.dirname(fullPath))) {
-              mkdirSync(path.dirname(fullPath), { recursive: true });
-            }
+            makeDirectoryRecursively(path.dirname(fullPath));
             writeFileSync(fullPath, expectedContent);
           }
         },

--- a/packages/rules/src/fileContents.ts
+++ b/packages/rules/src/fileContents.ts
@@ -7,7 +7,7 @@
 
 import { Context } from "@monorepolint/core";
 import { RuleModule } from "@monorepolint/core";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import diff from "jest-diff";
 import * as path from "path";
 import * as r from "runtypes";
@@ -43,7 +43,8 @@ export const fileContents = {
     const generator = getGenerator(context, opts);
     const expectedContent = generator(context);
 
-    const actualContent = existsSync(fullPath) ? readFileSync(fullPath, "utf-8") : undefined;
+    const pathExists = existsSync(fullPath);
+    const actualContent = pathExists ? readFileSync(fullPath, "utf-8") : undefined;
 
     if (actualContent !== expectedContent) {
       context.addError({
@@ -51,9 +52,12 @@ export const fileContents = {
         message: "Expect file contents to match",
         longMessage: diff(expectedContent, actualContent, { expand: true }),
         fixer: () => {
-          if (expectedContent === undefined) {
+          if (expectedContent === undefined && pathExists) {
             unlinkSync(fullPath);
           } else {
+            if (!existsSync(path.dirname(fullPath))) {
+              mkdirSync(path.dirname(fullPath), { recursive: true });
+            }
             writeFileSync(fullPath, expectedContent);
           }
         },

--- a/packages/rules/src/util/makeDirectory.ts
+++ b/packages/rules/src/util/makeDirectory.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2019 Palantir Technologies, Inc.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ */
+
+import { existsSync, mkdirSync } from "fs";
+import * as path from "path";
+
+export function makeDirectoryRecursively(directoryPath: string) {
+  // node < 10 doesn't support mkdirSync w/ recursive: true
+  // so we manually do it instead
+  const dirSegments = directoryPath.split(path.sep);
+  for (let i = 0; i < dirSegments.length; i++) {
+    if (dirSegments[i].length > 0) {
+      // we skip the empty segment
+      const curDirPath = dirSegments.slice(0, i + 1).join(path.sep);
+      if (!existsSync(curDirPath)) {
+        mkdirSync(curDirPath);
+      }
+    }
+  }
+}


### PR DESCRIPTION
If I'm trying to copy over a nested file into every package (e.g. `packages/foo/file`) and `packages/foo` does not exist, monorepolint currently throws