### PR TITLE
Add entriesExists option to packageEntry rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,6 +1,6 @@
 # Rules
 
-Monorepolint comes with a number of builtin rules. 
+Monorepolint comes with a number of builtin rules.
 
 To add your own custom rules see `writing-custom-rules.md`
 
@@ -76,7 +76,7 @@ Enforce each package has a file with certain contents enforced by either a templ
 * `template` (Optional)
   - Expected file contents
 * `templateFile` (Optional)
-  - Path to a file to use as a template 
+  - Path to a file to use as a template
 
 Exactly one of `generator`, `template`, or `templateFile` needs to be specified.
 
@@ -104,6 +104,8 @@ Standardize arbitrary entries in package.json.
 
 * `entries`
   - An object of expected key value pairs for the package.json
+* `entriesExists`
+  - An array of expected keys to exist in package.json (without any value enforcement)
 
 ### Example
 
@@ -114,7 +116,10 @@ module.exports = {
       options: {
         entries: {
           "author": "Eric L Anderson (https://github.com/ericanderson)"
-        }
+        },
+        entriesExists: [
+          "bugs"
+        ]
       }
     }
   }
@@ -224,7 +229,7 @@ Special case of the File Contents rule for typescript configs. Using a template 
 * `template` (Optional)
   - Expected config contents
 * `templateFile` (Optional)
-  - Path to a file to use as a template 
+  - Path to a file to use as a template
 
 Exactly one of `generator`, `template`, or `templateFile` needs to be specified.
 

--- a/packages/rules/src/packageEntry.ts
+++ b/packages/rules/src/packageEntry.ts
@@ -11,14 +11,24 @@ import diff from "jest-diff";
 import * as r from "runtypes";
 
 export const Options = r.Union(
-  r.Record({
-    entries: r.Dictionary(r.Unknown), // string => unknown, enforces existence of keys and their values
-    entriesExist: r.Undefined,
-  }),
-  r.Record({
-    entries: r.Undefined,
-    entriesExist: r.Array(r.String), // enforces existence of keys, but not values
-  }),
+  r
+    .Record({
+      entries: r.Dictionary(r.Unknown), // string => unknown, enforces existence of keys and their values
+    })
+    .And(
+      r.Partial({
+        entriesExist: r.Undefined,
+      })
+    ),
+  r
+    .Record({
+      entriesExist: r.Array(r.String), // enforces existence of keys, but not values
+    })
+    .And(
+      r.Partial({
+        entries: r.Undefined,
+      })
+    ),
   r.Record({
     entries: r.Dictionary(r.Unknown), // string => unknown, enforces existence of keys and their values
     entriesExist: r.Array(r.String),

--- a/packages/rules/src/packageEntry.ts
+++ b/packages/rules/src/packageEntry.ts
@@ -10,9 +10,20 @@ import { mutateJson, PackageJson } from "@monorepolint/utils";
 import diff from "jest-diff";
 import * as r from "runtypes";
 
-export const Options = r.Record({
-  entries: r.Dictionary(r.Unknown), // string => unknown
-});
+export const Options = r.Union(
+  r.Record({
+    entries: r.Dictionary(r.Unknown), // string => unknown, enforces existence of keys and their values
+    entriesExist: r.Undefined,
+  }),
+  r.Record({
+    entries: r.Undefined,
+    entriesExist: r.Array(r.String), // enforces existence of keys, but not values
+  }),
+  r.Record({
+    entries: r.Dictionary(r.Unknown), // string => unknown, enforces existence of keys and their values
+    entriesExist: r.Array(r.String),
+  })
+);
 
 export type Options = r.Static<typeof Options>;
 
@@ -20,25 +31,38 @@ export const packageEntry = {
   check: function expectPackageEntry(context: Context, options: Options) {
     const packageJson = context.getPackageJson();
 
-    for (const key of Object.keys(options.entries)) {
-      const value = options.entries[key];
+    if (options.entries) {
+      for (const key of Object.keys(options.entries)) {
+        const value = options.entries[key];
 
-      const entryDiff = diff(JSON.stringify(value) + "\n", (JSON.stringify(packageJson[key]) || "") + "\n");
-      if (
-        (typeof value !== "object" && value !== packageJson[key]) ||
-        (entryDiff == null || !entryDiff.includes("Compared values have no visual difference"))
-      ) {
-        context.addError({
-          file: context.getPackageJsonPath(),
-          message: `Expected standardized entry for '${key}'`,
-          longMessage: entryDiff,
-          fixer: () => {
-            mutateJson<PackageJson>(context.getPackageJsonPath(), input => {
-              input[key] = value;
-              return input;
-            });
-          },
-        });
+        const entryDiff = diff(JSON.stringify(value) + "\n", (JSON.stringify(packageJson[key]) || "") + "\n");
+        if (
+          (typeof value !== "object" && value !== packageJson[key]) ||
+          (entryDiff == null || !entryDiff.includes("Compared values have no visual difference"))
+        ) {
+          context.addError({
+            file: context.getPackageJsonPath(),
+            message: `Expected standardized entry for '${key}'`,
+            longMessage: entryDiff,
+            fixer: () => {
+              mutateJson<PackageJson>(context.getPackageJsonPath(), input => {
+                input[key] = value;
+                return input;
+              });
+            },
+          });
+        }
+      }
+    }
+
+    if (options.entriesExist) {
+      for (const key of options.entriesExist) {
+        if (packageJson[key] === undefined) {
+          context.addError({
+            file: context.getPackageJsonPath(),
+            message: `Expected entry for '${key}' to exist`,
+          });
+        }
       }
     }
   },


### PR DESCRIPTION
I have found that sometimes I would like to enforce that a particular field in package.json exists, but don't have a uniform value to provide for the field. To that end, I've added an `entriesExists` field to enable this enforcement in the existing `packageEntry` rule