### PR TITLE
Add rule for nested workspaces

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -61,6 +61,24 @@ module.exports = {
 };
 ```
 
+
+## Nested Workspaces
+
+[source](https://github.com/monorepolint/monorepolint/blob/master/packages/rules/src/nestedWorkspaces.ts)
+
+Enforce that all workspaces in the repo are represented by the `workspaces` field in `package.json`.
+In particular, this ensures that nested workspaces (e.g. `packages/group/*`) are not missed.
+
+### Example
+
+```javascript
+module.exports = {
+  rules: {
+    ":nested-workspaces": true
+  }
+};
+```
+
 ## File Contents
 
 [source](https://github.com/monorepolint/monorepolint/blob/master/packages/rules/src/fileContents.ts)

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@monorepolint/core": "^0.4.0",
     "@monorepolint/utils": "^0.4.0",
-    "globby": "^11.0.0",
+    "globby": "^10.0.2",
     "jest-diff": "^24.9.0",
     "minimatch": "^3.0.4",
     "runtypes": "^4.0.0"

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@monorepolint/core": "^0.4.0",
     "@monorepolint/utils": "^0.4.0",
+    "globby": "^11.0.0",
     "jest-diff": "^24.9.0",
     "minimatch": "^3.0.4",
     "runtypes": "^4.0.0"

--- a/packages/rules/src/__tests__/nestedWorkspaces.spec.ts
+++ b/packages/rules/src/__tests__/nestedWorkspaces.spec.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright 2019 Palantir Technologies, Inc.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ */
+import { WorkspaceContext } from "@monorepolint/core";
+import { writeFileSync } from "fs";
+import * as path from "path";
+import * as tmp from "tmp";
+import { nestedWorkspaces } from "../nestedWorkspaces";
+import { makeDirectoryRecursively } from "../util/makeDirectory";
+import { jsonToString } from "./utils";
+
+const EMPTY_PACKAGE = jsonToString({});
+
+const PACKAGE_ROOT_WITH_PACKAGES_STAR = jsonToString({
+  workspaces: {
+    packages: ["packages/*"],
+  },
+});
+
+const PACKAGE_ROOT_WITH_TWO_LEVEL = jsonToString({
+  workspaces: {
+    packages: ["packages/*", "packages/deep/*"],
+  },
+});
+
+const PACKAGE_ROOT_WITH_THREE_LEVEL = jsonToString({
+  workspaces: {
+    packages: ["packages/*", "packages/deep/*", "packages/very/deep/*"],
+  },
+});
+
+describe("nestedWorkspaces", () => {
+  tmp.setGracefulCleanup();
+
+  let cleanupJobs: Array<() => void> = [];
+  let cwd: string | undefined;
+
+  beforeEach(() => {
+    const dir = tmp.dirSync();
+    cleanupJobs.push(() => dir.removeCallback());
+    cwd = dir.name;
+
+    const spy = jest.spyOn(process, "cwd");
+    spy.mockReturnValue(cwd);
+  });
+
+  afterEach(() => {
+    for (const cleanupJob of cleanupJobs) {
+      cleanupJob();
+    }
+    cleanupJobs = [];
+  });
+
+  function makeWorkspace({ fix }: { fix: boolean }) {
+    const workspaceContext = new WorkspaceContext(cwd!, {
+      rules: [],
+      fix,
+      verbose: false,
+      silent: true,
+    });
+
+    async function checkAndSpy() {
+      const addErrorSpy = jest.spyOn(workspaceContext, "addError");
+
+      await nestedWorkspaces.check(workspaceContext, undefined);
+      return { addErrorSpy };
+    }
+
+    function addFile(filePath: string, content: string) {
+      const dirPath = path.resolve(cwd!, path.dirname(filePath));
+      const resolvedFilePath = path.resolve(cwd!, filePath);
+
+      makeDirectoryRecursively(dirPath);
+      writeFileSync(resolvedFilePath, content);
+    }
+
+    return { addFile, workspaceContext, checkAndSpy };
+  }
+
+  it("checks correctly when no packages", async () => {
+    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    addFile("./package.json", EMPTY_PACKAGE);
+
+    expect((await checkAndSpy()).addErrorSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("checks correctly when one level packages", async () => {
+    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    addFile("./package.json", PACKAGE_ROOT_WITH_PACKAGES_STAR);
+    addFile("./packages/star/package.json", EMPTY_PACKAGE);
+
+    expect((await checkAndSpy()).addErrorSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("checks fail when one level packages with no workspaces field", async () => {
+    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    addFile("./package.json", EMPTY_PACKAGE);
+    addFile("./packages/star/package.json", EMPTY_PACKAGE);
+
+    expect((await checkAndSpy()).addErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks correctly when two level packages with two level workspaces field", async () => {
+    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    addFile("./package.json", PACKAGE_ROOT_WITH_TWO_LEVEL);
+    addFile("./packages/star/package.json", EMPTY_PACKAGE);
+    addFile("./packages/deep/star/package.json", EMPTY_PACKAGE);
+
+    expect((await checkAndSpy()).addErrorSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("checks fail when two level packages with one level workspaces field", async () => {
+    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    addFile("./package.json", PACKAGE_ROOT_WITH_PACKAGES_STAR);
+    addFile("./packages/star/package.json", EMPTY_PACKAGE);
+    addFile("./packages/deep/star/package.json", EMPTY_PACKAGE);
+
+    expect((await checkAndSpy()).addErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks correctly when three level packages with three level workspaces field", async () => {
+    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    addFile("./package.json", PACKAGE_ROOT_WITH_THREE_LEVEL);
+    addFile("./packages/star/package.json", EMPTY_PACKAGE);
+    addFile("./packages/deep/star/package.json", EMPTY_PACKAGE);
+    addFile("./packages/very/deep/star/package.json", EMPTY_PACKAGE);
+
+    expect((await checkAndSpy()).addErrorSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/rules/src/__tests__/nestedWorkspaces.spec.ts
+++ b/packages/rules/src/__tests__/nestedWorkspaces.spec.ts
@@ -54,10 +54,10 @@ describe("nestedWorkspaces", () => {
     cleanupJobs = [];
   });
 
-  function makeWorkspace({ fix }: { fix: boolean }) {
+  function makeWorkspace() {
     const workspaceContext = new WorkspaceContext(cwd!, {
       rules: [],
-      fix,
+      fix: false,
       verbose: false,
       silent: true,
     });
@@ -81,14 +81,14 @@ describe("nestedWorkspaces", () => {
   }
 
   it("checks correctly when no packages", async () => {
-    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    const { addFile, checkAndSpy } = makeWorkspace();
     addFile("./package.json", EMPTY_PACKAGE);
 
     expect((await checkAndSpy()).addErrorSpy).toHaveBeenCalledTimes(0);
   });
 
   it("checks correctly when one level packages", async () => {
-    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    const { addFile, checkAndSpy } = makeWorkspace();
     addFile("./package.json", PACKAGE_ROOT_WITH_PACKAGES_STAR);
     addFile("./packages/star/package.json", EMPTY_PACKAGE);
 
@@ -96,7 +96,7 @@ describe("nestedWorkspaces", () => {
   });
 
   it("checks fail when one level packages with no workspaces field", async () => {
-    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    const { addFile, checkAndSpy } = makeWorkspace();
     addFile("./package.json", EMPTY_PACKAGE);
     addFile("./packages/star/package.json", EMPTY_PACKAGE);
 
@@ -104,7 +104,7 @@ describe("nestedWorkspaces", () => {
   });
 
   it("checks correctly when two level packages with two level workspaces field", async () => {
-    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    const { addFile, checkAndSpy } = makeWorkspace();
     addFile("./package.json", PACKAGE_ROOT_WITH_TWO_LEVEL);
     addFile("./packages/star/package.json", EMPTY_PACKAGE);
     addFile("./packages/deep/star/package.json", EMPTY_PACKAGE);
@@ -113,7 +113,7 @@ describe("nestedWorkspaces", () => {
   });
 
   it("checks fail when two level packages with one level workspaces field", async () => {
-    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    const { addFile, checkAndSpy } = makeWorkspace();
     addFile("./package.json", PACKAGE_ROOT_WITH_PACKAGES_STAR);
     addFile("./packages/star/package.json", EMPTY_PACKAGE);
     addFile("./packages/deep/star/package.json", EMPTY_PACKAGE);
@@ -122,7 +122,7 @@ describe("nestedWorkspaces", () => {
   });
 
   it("checks correctly when three level packages with three level workspaces field", async () => {
-    const { addFile, checkAndSpy } = makeWorkspace({ fix: false });
+    const { addFile, checkAndSpy } = makeWorkspace();
     addFile("./package.json", PACKAGE_ROOT_WITH_THREE_LEVEL);
     addFile("./packages/star/package.json", EMPTY_PACKAGE);
     addFile("./packages/deep/star/package.json", EMPTY_PACKAGE);

--- a/packages/rules/src/__tests__/nestedWorkspaces.spec.ts
+++ b/packages/rules/src/__tests__/nestedWorkspaces.spec.ts
@@ -130,7 +130,7 @@ describe("nestedWorkspaces", () => {
       file: packageJsonPath,
       message:
         'The "workspace" field is missing one or more values: packages/deep/star. ' +
-        'You may be able to use a glob to avoid listing each out individually, e.g. "packages/nested-workspace/*".',
+        'You may be able to use a glob to avoid listing each workspace individually, e.g. "packages/nested-workspace/*".',
     });
   });
 

--- a/packages/rules/src/index.ts
+++ b/packages/rules/src/index.ts
@@ -14,3 +14,4 @@ export { packageOrder } from "./packageOrder";
 export { packageEntry } from "./packageEntry";
 export { packageScript } from "./packageScript";
 export { standardTsconfig } from "./standardTsconfig";
+export { nestedWorkspaces } from "./nestedWorkspaces";

--- a/packages/rules/src/nestedWorkspaces.ts
+++ b/packages/rules/src/nestedWorkspaces.ts
@@ -52,7 +52,7 @@ export const nestedWorkspaces: RuleModule<typeof Options> = {
         file: context.getPackageJsonPath(),
         message:
           `The "workspace" field is missing one or more values: ${differencesList}. ` +
-          'You may be able to use a glob to avoid listing each out individually, e.g. "packages/nested-workspace/*".',
+          'You may be able to use a glob to avoid listing each workspace individually, e.g. "packages/nested-workspace/*".',
       });
     }
   },

--- a/packages/rules/src/nestedWorkspaces.ts
+++ b/packages/rules/src/nestedWorkspaces.ts
@@ -14,8 +14,7 @@ export const Options = r.Undefined;
 
 type Options = r.Static<typeof Options>;
 
-// Custom monorepolint rule to enforce that the root package.json contains
-// all of the workspaces in the repo (including nested packages)
+// Enforce that the root package.json contains all of the workspaces in the repo (including nested packages)
 export const nestedWorkspaces: RuleModule<typeof Options> = {
   check: async (context: Context) => {
     const rootPackageJson = context.getWorkspaceContext().getPackageJson();

--- a/packages/rules/src/nestedWorkspaces.ts
+++ b/packages/rules/src/nestedWorkspaces.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2019 Palantir Technologies, Inc.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ */
+
+import { Context, RuleModule } from "@monorepolint/core";
+import globby from "globby";
+import * as r from "runtypes";
+
+export const Options = r.Undefined;
+
+type Options = r.Static<typeof Options>;
+
+// Custom monorepolint rule to enforce that the root package.json contains
+// all of the workspaces in the repo (including nested packages)
+export const nestedWorkspaces: RuleModule<typeof Options> = {
+  check: async (context: Context) => {
+    const rootPackageJson = context.getWorkspaceContext().getPackageJson();
+
+    // Expand a set of globs covering all package.json files in the entire repo (except the root)
+    const packageJsonPaths = await globby(["*/**/package.json", "!**/node_modules/**"]);
+
+    const workspaces = Array.isArray(rootPackageJson.workspaces)
+      ? rootPackageJson.workspaces
+      : rootPackageJson.workspaces !== undefined
+      ? rootPackageJson.workspaces.packages
+      : undefined;
+
+    if (workspaces === undefined && packageJsonPaths.length > 0) {
+      context.addError({
+        file: context.getPackageJsonPath(),
+        message: 'The "workspace" field is missing, even though there are workspaces in the repository.',
+      });
+      return;
+    }
+
+    // Build a set of globs for each package.json that exists in packages specified by a workspace.
+    const workspacePackageJsons = (workspaces || []).map(item => `${item}/package.json`);
+
+    // Expand the globs to get an array of all package.json files that are in packages specified by a workspace.
+    const expandedWorkspacesGlobs = await globby([...workspacePackageJsons, "!**/node_modules/**"]);
+
+    // Check that sets are equal (we know the inverse is true already)
+    const setsAreEqual = packageJsonPaths.every(packageJsonPath => expandedWorkspacesGlobs.includes(packageJsonPath));
+
+    if (!setsAreEqual) {
+      context.addError({
+        file: context.getPackageJsonPath(),
+        message:
+          'The "workspace" field is missing one or more values. This is usually because there is an unlisted nested workspace.' +
+          'Nested workspaces should be listed individually, e.g. "packages/workspace-a/*".',
+      });
+    }
+  },
+  optionsRuntype: Options,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,7 +2499,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
 
 es-abstract@^1.4.3, es-abstract@^1.5.1:
   version "1.17.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.0.tgz#f42a517d0036a5591dbb2c463591dc8bb50309b1"
+  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz#f42a517d0036a5591dbb2c463591dc8bb50309b1"
   integrity sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==
   dependencies:
     es-to-primitive "^1.2.1"
@@ -2516,7 +2516,7 @@ es-abstract@^1.4.3, es-abstract@^1.5.1:
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  resolved "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
   integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
@@ -3238,8 +3238,8 @@ has-symbols@^1.0.0:
 
 has-symbols@^1.0.1:
   version "1.0.1"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
-  integrity sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
@@ -3524,8 +3524,8 @@ is-callable@^1.1.4:
 
 is-callable@^1.1.5:
   version "1.1.5"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
-  integrity sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=
+  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
+  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -3691,8 +3691,8 @@ is-promise@^2.1.0:
 
 is-regex@^1.0.5:
   version "1.0.5"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=
+  resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
+  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
   dependencies:
     has "^1.0.3"
 
@@ -5201,8 +5201,8 @@ object-copy@^0.1.0:
 
 object-inspect@^1.7.0:
   version "1.7.0"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
-  integrity sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=
+  resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
+  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -5218,8 +5218,8 @@ object-visit@^1.0.0:
 
 object.assign@^4.1.0:
   version "4.1.0"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=
+  resolved "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
   dependencies:
     define-properties "^1.1.2"
     function-bind "^1.1.1"
@@ -6539,16 +6539,16 @@ string.prototype.padend@^3.0.0:
 
 string.prototype.trimleft@^2.1.1:
   version "2.1.1"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
-  integrity sha1-m9uKxqvW1gKxek7TIYcNL43O/HQ=
+  resolved "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
+  integrity sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==
   dependencies:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
 string.prototype.trimright@^2.1.1:
   version "2.1.1"
-  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
-  integrity sha1-RAMUsVmWyGbOigNBiU1FGGIAxdk=
+  resolved "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
+  integrity sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==
   dependencies:
     define-properties "^1.1.3"
     function-bind "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,23 +1055,10 @@
     "@nodelib/fs.stat" "2.0.2"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.scandir@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
-  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
-  dependencies:
-    "@nodelib/fs.stat" "2.0.3"
-    run-parallel "^1.1.9"
-
 "@nodelib/fs.stat@2.0.2", "@nodelib/fs.stat@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz#2762aea8fe78ea256860182dcb52d61ee4b8fda6"
   integrity sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==
-
-"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
-  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -1084,14 +1071,6 @@
   integrity sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==
   dependencies:
     "@nodelib/fs.scandir" "2.1.2"
-    fastq "^1.6.0"
-
-"@nodelib/fs.walk@^1.2.3":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
-  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
-  dependencies:
-    "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
 "@octokit/endpoint@^5.1.0":
@@ -2722,17 +2701,6 @@ fast-glob@^3.0.3:
     merge2 "^1.2.3"
     micromatch "^4.0.2"
 
-fast-glob@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
-  integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -3105,13 +3073,6 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -3148,16 +3109,18 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
-  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
+globby@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"
+  integrity sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
   dependencies:
+    "@types/glob" "^7.1.1"
     array-union "^2.1.0"
     dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
     slash "^3.0.0"
 
 globby@^6.1.0:
@@ -3382,7 +3345,7 @@ ignore@^4.0.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4:
+ignore@^5.1.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -4720,11 +4683,6 @@ merge2@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.4.tgz#c9269589e6885a60cf80605d9522d4b67ca646e3"
   integrity sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==
-
-merge2@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
-  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,10 +1055,23 @@
     "@nodelib/fs.stat" "2.0.2"
     run-parallel "^1.1.9"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
 "@nodelib/fs.stat@2.0.2", "@nodelib/fs.stat@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz#2762aea8fe78ea256860182dcb52d61ee4b8fda6"
   integrity sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -1071,6 +1084,14 @@
   integrity sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==
   dependencies:
     "@nodelib/fs.scandir" "2.1.2"
+    fastq "^1.6.0"
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
 "@octokit/endpoint@^5.1.0":
@@ -2276,7 +2297,7 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-define-properties@^1.1.2:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -2477,25 +2498,26 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.4.3, es-abstract@^1.5.1:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.0.tgz#f59d9d44278ea8f90c8ff3de1552537c2fd739b4"
-  integrity sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.0.tgz#f42a517d0036a5591dbb2c463591dc8bb50309b1"
+  integrity sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==
   dependencies:
-    es-to-primitive "^1.2.0"
+    es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.0"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-inspect "^1.6.0"
+    has-symbols "^1.0.1"
+    is-callable "^1.1.5"
+    is-regex "^1.0.5"
+    object-inspect "^1.7.0"
     object-keys "^1.1.1"
-    string.prototype.trimleft "^2.0.0"
-    string.prototype.trimright "^2.0.0"
+    object.assign "^4.1.0"
+    string.prototype.trimleft "^2.1.1"
+    string.prototype.trimright "^2.1.1"
 
-es-to-primitive@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
-  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
@@ -2698,6 +2720,17 @@ fast-glob@^3.0.3:
     glob-parent "^5.0.0"
     is-glob "^4.0.1"
     merge2 "^1.2.3"
+    micromatch "^4.0.2"
+
+fast-glob@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
+  integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
     micromatch "^4.0.2"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
@@ -3072,6 +3105,13 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -3106,6 +3146,18 @@ globby@^10.0.1:
     glob "^7.1.3"
     ignore "^5.1.1"
     merge2 "^1.2.3"
+    slash "^3.0.0"
+
+globby@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
+  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
     slash "^3.0.0"
 
 globby@^6.1.0:
@@ -3184,6 +3236,11 @@ has-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
   integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
+has-symbols@^1.0.1:
+  version "1.0.1"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=
+
 has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -3220,7 +3277,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@^1.0.3:
+has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -3325,7 +3382,7 @@ ignore@^4.0.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -3464,6 +3521,11 @@ is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
+is-callable@^1.1.5:
+  version "1.1.5"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
+  integrity sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -3627,12 +3689,12 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+is-regex@^1.0.5:
+  version "1.0.5"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
+  integrity sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=
   dependencies:
-    has "^1.0.1"
+    has "^1.0.3"
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -4659,6 +4721,11 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.4.tgz#c9269589e6885a60cf80605d9522d4b67ca646e3"
   integrity sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==
 
+merge2@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
+  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -5132,12 +5199,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
-  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+object-inspect@^1.7.0:
+  version "1.7.0"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
+  integrity sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -5148,6 +5215,16 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -6460,21 +6537,21 @@ string.prototype.padend@^3.0.0:
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
 
-string.prototype.trimleft@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz#68b6aa8e162c6a80e76e3a8a0c2e747186e271ff"
-  integrity sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=
+string.prototype.trimleft@^2.1.1:
+  version "2.1.1"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
+  integrity sha1-m9uKxqvW1gKxek7TIYcNL43O/HQ=
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.0.2"
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
 
-string.prototype.trimright@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz#ab4a56d802a01fbe7293e11e84f24dc8164661dd"
-  integrity sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=
+string.prototype.trimright@^2.1.1:
+  version "2.1.1"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
+  integrity sha1-RAMUsVmWyGbOigNBiU1FGGIAxdk=
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.0.2"
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
 
 string_decoder@^1.1.1:
   version "1.3.0"


### PR DESCRIPTION
Ensure that the `workspaces` field in the root `package.json` is correct by checking all of the packages in the repo, and ensuring that the workspaces in the `workspaces` field cover all the found packages.

Not sure what the deal is with the yarn.lock file - seems like things in there are mostly `yarnpkg` and `palantir` registries but I can't get my registry to set to the yarnpkg one (and clearly the palantir one is wrong).

This rule doesn't have a fixer. I can attempt to add one if you think it should have one.