### PR TITLE
Always print long error message

### DIFF
--- a/packages/core/src/PackageContext.ts
+++ b/packages/core/src/PackageContext.ts
@@ -75,7 +75,7 @@ export class PackageContext implements Context {
       this.setFailed();
       this.printError(`${chalk.red("Error!")} ${chalk.magenta(shortFile)}: ${message}`);
 
-      if (this.resolvedConfig.verbose && longMessage) {
+      if (longMessage) {
         for (let i = 0; i <= this.depth + 1; i++) {
           // tslint:disable-next-line:no-console
           console.group();


### PR DESCRIPTION
I've been trying to print error messages with the following format:
```
{
  message: "Package <foo> has conflicting inherited peer dependencies for <react>",
  longMessage: "Dependency <foo-lib> requires <^15> and dependency <foo-utils> requires <^16>",
}
```

There's a lot of detail to jam into one sentence. I'd like to see the `longMessage` for errors, but I don't want everything that `verbose` logging brings with it.

Does it seem reasonable to always print the `longMessage` for errors?