### PR TITLE
Resolve monorepolint rules from the context of the workspace root

### DIFF
--- a/packages/core/src/resolveConfig.ts
+++ b/packages/core/src/resolveConfig.ts
@@ -89,10 +89,10 @@ function loadRuleModule(type: string, workspaceRootDir: string) {
   } else if (type.includes(":")) {
     // if the type includes `:`, then we should import a const rather than default
     const [packageName, ruleVariable] = type.split(":");
-    mod = require(packageName)[camelCase(ruleVariable)];
+    mod = require(require.resolve(packageName, { paths: [workspaceRootDir] }))[camelCase(ruleVariable)];
   } else {
     // otherwise just import the default
-    mod = __importDefault(require(type)).default;
+    mod = __importDefault(require(require.resolve(type, { paths: [workspaceRootDir] }))).default;
   }
 
   try {


### PR DESCRIPTION
Resolve rule packages from the context of the workspace calling monorepolint, not from the context of monorepolint itself. 

A lot of the time this won't matter since monorepolint will have access to packages in the workspace that have been hoisted, by virtue of how it's installed in `node_modules`. I ran into this while trying to `yarn link` monorepolint in to another repository which has a private rules package. 