### PR TITLE
[peer deps] Replace usage of `longMessage` with concatenated `message`

### DIFF
--- a/packages/rules/src/__tests__/mustSatisfyPeerDependencies.spec.ts
+++ b/packages/rules/src/__tests__/mustSatisfyPeerDependencies.spec.ts
@@ -493,10 +493,8 @@ describe("mustSatisfyPeerDependencies", () => {
     const { addErrorSpy } = checkAndSpy(false);
     expect(addErrorSpy).toHaveBeenCalledTimes(1);
     expect(addErrorSpy.mock.calls[0][0].message).toEqual(
-      `[0] Package ${testPackageJson.name} has overloaded greatLib dependencies.`
-    );
-    expect(addErrorSpy.mock.calls[0][0].longMessage).toEqual(
-      `Peer dependency '${testPackageJson.peerDependencies.greatLib}' and regular dependency '${testPackageJson.dependencies.greatLib}'.`
+      `[0] Package ${testPackageJson.name} has overloaded greatLib dependencies.\n\t` +
+        `Peer dependency '${testPackageJson.peerDependencies.greatLib}' and regular dependency '${testPackageJson.dependencies.greatLib}'.`
     );
   });
 
@@ -533,10 +531,8 @@ describe("mustSatisfyPeerDependencies", () => {
     const { addErrorSpy } = checkAndSpy(false);
     expect(addErrorSpy).toHaveBeenCalledTimes(1);
     expect(addErrorSpy.mock.calls[0][0].message).toEqual(
-      `[1] Package ${testPackageJson.name} has conflicting inherited greatLib peer dependencies.`
-    );
-    expect(addErrorSpy.mock.calls[0][0].longMessage).toEqual(
-      `Dependency ${bbbPackageJson.name} requires '${bbbPackageJson.peerDependencies.greatLib}' but dependency ${aaaPackageJson.name} requires '${aaaPackageJson.peerDependencies.greatLib}'.`
+      `[1] Package ${testPackageJson.name} has conflicting inherited greatLib peer dependencies.\n\t` +
+        `Dependency ${bbbPackageJson.name} requires '${bbbPackageJson.peerDependencies.greatLib}' but dependency ${aaaPackageJson.name} requires '${aaaPackageJson.peerDependencies.greatLib}'.`
     );
   });
 
@@ -575,10 +571,8 @@ describe("mustSatisfyPeerDependencies", () => {
     const { addErrorSpy } = checkAndSpy(false);
     expect(addErrorSpy).toHaveBeenCalledTimes(1);
     expect(addErrorSpy.mock.calls[0][0].message).toEqual(
-      `[2] Package ${testPackageJson.name} dependency on greatLib '${testPackageJson.dependencies.greatLib}' does not satisfy inherited peer dependencies.`
-    );
-    expect(addErrorSpy.mock.calls[0][0].longMessage).toEqual(
-      `Dependency ${bbbPackageJson.name} requires '${bbbPackageJson.peerDependencies.greatLib}' or stricter.`
+      `[2] Package ${testPackageJson.name} dependency on greatLib '${testPackageJson.dependencies.greatLib}' does not satisfy inherited peer dependencies.\n\t` +
+        `Dependency ${bbbPackageJson.name} requires '${bbbPackageJson.peerDependencies.greatLib}' or stricter.`
     );
   });
 
@@ -612,7 +606,8 @@ describe("mustSatisfyPeerDependencies", () => {
     const { addErrorSpy } = checkAndSpy(false);
     expect(addErrorSpy).toHaveBeenCalledTimes(1);
     expect(addErrorSpy.mock.calls[0][0].message).toEqual(
-      `[3] Package ${testPackageJson.name} is missing required greatLib dependency.`
+      `[3] Package ${testPackageJson.name} is missing required greatLib dependency.\n\t` +
+        `Dependency ${bbbPackageJson.name} requires '${bbbPackageJson.peerDependencies.greatLib}' or stricter.`
     );
     expect(readTestPackageJson().peerDependencies!.greatLib).toEqual(bbbPackageJson.peerDependencies.greatLib);
   });
@@ -650,7 +645,8 @@ describe("mustSatisfyPeerDependencies", () => {
     const { addErrorSpy } = checkAndSpy(false);
     expect(addErrorSpy).toHaveBeenCalledTimes(1);
     expect(addErrorSpy.mock.calls[0][0].message).toEqual(
-      `[4] Package ${testPackageJson.name} peer dependency on greatLib '${testPackageJson.peerDependencies.greatLib}' is not strict enough.`
+      `[4] Package ${testPackageJson.name} peer dependency on greatLib '${testPackageJson.peerDependencies.greatLib}' is not strict enough.\n\t` +
+        `Dependency ${bbbPackageJson.name} requires '${bbbPackageJson.peerDependencies.greatLib}' or stricter.`
     );
     expect(readTestPackageJson().peerDependencies!.greatLib).toEqual(bbbPackageJson.peerDependencies.greatLib);
   });

--- a/packages/rules/src/mustSatisfyPeerDependencies.ts
+++ b/packages/rules/src/mustSatisfyPeerDependencies.ts
@@ -101,8 +101,9 @@ function checkSatisfyPeerDependencies(context: Context, opts: Options) {
     if (dependencyRange != null) {
       context.addError({
         file: packageJsonPath,
-        message: `[0] Package ${packageName} has overloaded ${peerDependencyName} dependencies.`,
-        longMessage: `Peer dependency '${peerDependencyRange}' and regular dependency '${dependencyRange}'.`,
+        message:
+          `[0] Package ${packageName} has overloaded ${peerDependencyName} dependencies.\n\t` +
+          `Peer dependency '${peerDependencyRange}' and regular dependency '${dependencyRange}'.`,
       });
     }
   }
@@ -148,8 +149,8 @@ function checkSatisfyPeerDependencies(context: Context, opts: Options) {
         } else if (!doesASatisfyB(mostStrictPeerRequirement.range, peerRequirement.range)) {
           context.addError({
             file: packageJsonPath,
-            message: `[1] Package ${packageName} has conflicting inherited ${peerDependencyName} peer dependencies.`,
-            longMessage:
+            message:
+              `[1] Package ${packageName} has conflicting inherited ${peerDependencyName} peer dependencies.\n\t` +
               `Dependency ${peerRequirement.node.packageJson.name} requires '${peerRequirement.range}' but ` +
               `dependency ${mostStrictPeerRequirement.node.packageJson.name} requires '${mostStrictPeerRequirement.range}'.`,
           });
@@ -171,8 +172,9 @@ function checkSatisfyPeerDependencies(context: Context, opts: Options) {
       } else if (!doesASatisfyB(packageDependencyRange, mostStrictPeerRequirement.range)) {
         context.addError({
           file: packageJsonPath,
-          message: `[2] Package ${packageName} dependency on ${peerDependencyName} '${packageDependencyRange}' does not satisfy inherited peer dependencies.`,
-          longMessage: `Dependency ${mostStrictPeerRequirement.node.packageJson.name} requires '${mostStrictPeerRequirement.range}' or stricter.`,
+          message:
+            `[2] Package ${packageName} dependency on ${peerDependencyName} '${packageDependencyRange}' does not satisfy inherited peer dependencies.\n\t` +
+            `Dependency ${mostStrictPeerRequirement.node.packageJson.name} requires '${mostStrictPeerRequirement.range}' or stricter.`,
         });
       }
     }
@@ -183,8 +185,9 @@ function checkSatisfyPeerDependencies(context: Context, opts: Options) {
     if (packageDependencyRange == null && packagePeerDependencyRange == null) {
       context.addError({
         file: packageJsonPath,
-        message: `[3] Package ${packageName} is missing required ${peerDependencyName} dependency.`,
-        longMessage: `Dependency ${mostStrictPeerRequirement.node.packageJson.name} requires '${mostStrictPeerRequirement.range}' or stricter.`,
+        message:
+          `[3] Package ${packageName} is missing required ${peerDependencyName} dependency.\n\t` +
+          `Dependency ${mostStrictPeerRequirement.node.packageJson.name} requires '${mostStrictPeerRequirement.range}' or stricter.`,
         fixer: getAddDependencyTypeFixer({
           packageJsonPath,
           dependencyType: "peerDependencies",
@@ -207,8 +210,9 @@ function checkSatisfyPeerDependencies(context: Context, opts: Options) {
       } else if (!doesASatisfyB(packagePeerDependencyRange, mostStrictPeerRequirement.range)) {
         context.addError({
           file: packageJsonPath,
-          message: `[4] Package ${packageName} peer dependency on ${peerDependencyName} '${packagePeerDependencyRange}' is not strict enough.`,
-          longMessage: `Dependency ${mostStrictPeerRequirement.node.packageJson.name} requires '${mostStrictPeerRequirement.range}' or stricter.`,
+          message:
+            `[4] Package ${packageName} peer dependency on ${peerDependencyName} '${packagePeerDependencyRange}' is not strict enough.\n\t` +
+            `Dependency ${mostStrictPeerRequirement.node.packageJson.name} requires '${mostStrictPeerRequirement.range}' or stricter.`,
           fixer: getAddDependencyTypeFixer({
             packageJsonPath,
             dependencyType: "peerDependencies",


### PR DESCRIPTION
`longMessage` is only shown in `verbose` mode (incredibly noisey),
but `mustSatisfyPeerDependencies` was putting crucial error
information in `longMessage`