### PR TITLE
Use `console.log` for warnings

### DIFF
--- a/packages/core/src/PackageContext.ts
+++ b/packages/core/src/PackageContext.ts
@@ -127,7 +127,7 @@ export class PackageContext implements Context {
       return;
     }
     // tslint:disable-next-line:no-console
-    console.warn(this.getMessage(str, depth));
+    console.log(this.getMessage(str, depth));
   }
 
   private printError(str: string, depth: number = this.depth + 1) {

--- a/packages/core/src/PackageContext.ts
+++ b/packages/core/src/PackageContext.ts
@@ -126,9 +126,9 @@ export class PackageContext implements Context {
     if (this.resolvedConfig.silent) {
       return;
     }
-    // tslint:disable-next-line:no-console
     // In nodejs, `console.warn` is an alias for `console.error`,
-    // which is undesirable for unfixable or unimportant warnings. 
+    // which is undesirable for unfixable or unimportant warnings.
+    // tslint:disable-next-line:no-console
     console.log(this.getMessage(str, depth));
   }
 

--- a/packages/core/src/PackageContext.ts
+++ b/packages/core/src/PackageContext.ts
@@ -127,8 +127,8 @@ export class PackageContext implements Context {
       return;
     }
     // tslint:disable-next-line:no-console
-	// In nodejs, `console.warn` is an alias for `console.error`,
-	// which is undesirable for unfixable or unimportant warnings. 
+    // In nodejs, `console.warn` is an alias for `console.error`,
+    // which is undesirable for unfixable or unimportant warnings. 
     console.log(this.getMessage(str, depth));
   }
 

--- a/packages/core/src/PackageContext.ts
+++ b/packages/core/src/PackageContext.ts
@@ -127,6 +127,8 @@ export class PackageContext implements Context {
       return;
     }
     // tslint:disable-next-line:no-console
+	// In nodejs, `console.warn` is an alias for `console.error`,
+	// which is undesirable for unfixable or unimportant warnings. 
     console.log(this.getMessage(str, depth));
   }
 


### PR DESCRIPTION
`console.warn` is just an alias for `console.error` in nodejs