### PR TITLE
Support alternative tsconfig paths in standardTsconfig rule

### DIFF
--- a/packages/docs/docs/rules/standard-tsconfig.md
+++ b/packages/docs/docs/rules/standard-tsconfig.md
@@ -6,6 +6,8 @@ Special case of the File Contents rule for typescript configs. Using a template 
 
 ### Options
 
+- `file` (Optional)
+  - Name of the file. Defaults to `tsconfig.json`.
 - `generator` (Optional)
   - Function that can generate the config
 - `template` (Optional)

--- a/packages/docs/docs/rules/standard-tsconfig.md
+++ b/packages/docs/docs/rules/standard-tsconfig.md
@@ -10,6 +10,8 @@ Special case of the File Contents rule for typescript configs. Using a template 
   - Name of the file. Defaults to `tsconfig.json`.
 - `generator` (Optional)
   - Function that can generate the config
+- `tsconfigReferenceFile` (Optional)
+  - String to append to each project reference path. Useful if project references have a non-standard `tsconfig.json` path. Ex: `tsconfig.build.json`.
 - `template` (Optional)
   - Expected config contents
 - `templateFile` (Optional)

--- a/packages/rules/src/standardTsconfig.ts
+++ b/packages/rules/src/standardTsconfig.ts
@@ -19,6 +19,7 @@ const Options = r
   .Partial({
     file: r.String,
     generator: r.Function,
+    tsconfigReferenceFile: r.String,
     template: r.Record({}).Or(r.String),
     templateFile: r.String,
     excludedReferences: r.Array(r.String).Or(r.Undefined),
@@ -79,15 +80,15 @@ function getGenerator(context: Context, opts: Options) {
     const fullPath = path.resolve(workspacePackageDir, opts.templateFile);
     const template = JSON.parse(readFileSync(fullPath, "utf-8"));
 
-    return makeGenerator(template, opts.excludedReferences);
+    return makeGenerator(template, opts.excludedReferences, opts.tsconfigReferenceFile);
   } else if (opts.template) {
-    return makeGenerator(opts.template, opts.excludedReferences);
+    return makeGenerator(opts.template, opts.excludedReferences, opts.tsconfigReferenceFile);
   } else {
     throw new Error("Unable to make generator");
   }
 }
 
-function makeGenerator(template: any, excludedReferences: ReadonlyArray<string> = []) {
+function makeGenerator(template: any, excludedReferences: ReadonlyArray<string> = [], tsconfigReferenceFile?: string) {
   return function generator(context: Context) {
     template = {
       ...template,
@@ -104,8 +105,11 @@ function makeGenerator(template: any, excludedReferences: ReadonlyArray<string> 
         (name) => nameToDirectory.has(name) && !excludedReferences.some((excludedRef) => minimatch(name, excludedRef))
       )
       .forEach((packageName) => {
+        const packageDir = nameToDirectory.get(packageName)!;
+        const absoluteReferencePath =
+          tsconfigReferenceFile !== undefined ? path.join(packageDir, tsconfigReferenceFile) : packageDir;
         template.references.push({
-          path: path.relative(context.packageDir, nameToDirectory.get(packageName)!),
+          path: path.relative(context.packageDir, absoluteReferencePath),
         });
       });
 

--- a/packages/rules/src/standardTsconfig.ts
+++ b/packages/rules/src/standardTsconfig.ts
@@ -13,8 +13,11 @@ import minimatch from "minimatch";
 import * as path from "path";
 import * as r from "runtypes";
 
+const DEFAULT_TSCONFIG_FILENAME = "tsconfig.json";
+
 const Options = r
   .Partial({
+    file: r.String,
     generator: r.Function,
     template: r.Record({}).Or(r.String),
     templateFile: r.String,
@@ -39,7 +42,8 @@ export type Options = r.Static<typeof Options>;
 
 export const standardTsconfig = {
   check: function expectStandardTsconfig(context: Context, opts: Options) {
-    const fullPath = path.resolve(context.packageDir, "tsconfig.json");
+    const tsconfigFileName = opts.file ?? DEFAULT_TSCONFIG_FILENAME;
+    const fullPath = path.resolve(context.packageDir, tsconfigFileName);
     const generator = getGenerator(context, opts);
     const expectedContent = generator(context);
 


### PR DESCRIPTION
This PR adds two new options to the `standardTsconfig` rule (`file` and `referenceTsconfigPath`) that make it easier to use alternative `tsconfig.json` file names.