### PR TITLE
Asynchronous rule checks and fixers

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,7 +47,7 @@ function getVersion(): string {
   return JSON.parse(fs.readFileSync(path.join(__dirname, "../package.json"), "utf-8")).version;
 }
 
-function handleCheck(args: Options) {
+async function handleCheck(args: Options) {
   // tslint:disable:no-console
   console.log("monorepolint (mrl) v" + getVersion());
   console.log();
@@ -56,7 +56,9 @@ function handleCheck(args: Options) {
   const config = Config.check(require(configPath));
   const resolvedConfig = resolveConfig(config, args, findWorkspaceDir(process.cwd())!);
 
-  if (!check(resolvedConfig, process.cwd(), args.paths)) {
+  const checkResult = await check(resolvedConfig, process.cwd(), args.paths);
+
+  if (!checkResult) {
     console.error();
 
     const execPath = process.env.npm_execpath;

--- a/packages/core/src/Config.ts
+++ b/packages/core/src/Config.ts
@@ -38,7 +38,9 @@ export interface Options {
   readonly silent?: boolean;
 }
 
-export type Checker<T extends Runtype> = (context: Context, args: r.Static<T>) => void;
+export type Checker<T extends Runtype> =
+  | ((context: Context, args: r.Static<T>) => void)
+  | ((context: Context, args: r.Static<T>) => Promise<void>);
 export type ResolvedRule = RuleModule & RuleEntry;
 export interface ResolvedConfig extends Options {
   readonly rules: ReadonlyArray<ResolvedRule>;

--- a/packages/core/src/Context.ts
+++ b/packages/core/src/Context.ts
@@ -20,6 +20,10 @@ export interface AddErrorOptions extends Failure {
   file: string;
 }
 
+export interface AddErrorAsyncOptions extends AddErrorOptions {
+  fixer?: () => Promise<void>;
+}
+
 export interface Context {
   readonly depth: number;
   readonly failed: boolean;
@@ -34,6 +38,7 @@ export interface Context {
   getPackageJson(): PackageJson;
   addWarning(opts: Failure): void;
   addError(opts: AddErrorOptions): void;
+  addErrorAsync(opts: AddErrorAsyncOptions): Promise<void>;
 
   isFailure(): boolean;
 

--- a/packages/core/src/Context.ts
+++ b/packages/core/src/Context.ts
@@ -15,6 +15,11 @@ export interface Failure {
   longMessage?: string | null;
   fixer?: () => void;
 }
+
+export interface AddErrorOptions extends Failure {
+  file: string;
+}
+
 export interface Context {
   readonly depth: number;
   readonly failed: boolean;
@@ -28,7 +33,7 @@ export interface Context {
 
   getPackageJson(): PackageJson;
   addWarning(opts: Failure): void;
-  addError(opts: Failure): void;
+  addError(opts: AddErrorOptions): void;
 
   isFailure(): boolean;
 

--- a/packages/core/src/PackageContext.ts
+++ b/packages/core/src/PackageContext.ts
@@ -9,15 +9,8 @@ import { PackageJson, readJson } from "@monorepolint/utils";
 import chalk from "chalk";
 import * as path from "path";
 import { ResolvedConfig } from "./Config";
-import { Context } from "./Context";
+import { AddErrorOptions, Context, Failure } from "./Context";
 import { WorkspaceContext } from "./WorkspaceContext";
-
-interface FailureOptions {
-  file: string;
-  message: string;
-  longMessage?: string;
-  fixer?: () => void;
-}
 
 // Right now, this stuff is done serially so we are writing less code to support that. Later we may want to redo this.
 export class PackageContext implements Context {
@@ -46,7 +39,7 @@ export class PackageContext implements Context {
     return readJson(this.getPackageJsonPath());
   }
 
-  public addWarning({ message, longMessage }: FailureOptions) {
+  public addWarning({ message, longMessage }: Failure) {
     this.printName();
 
     this.printWarning(`${chalk.yellow("Warning!")}: ${message}`);
@@ -63,7 +56,7 @@ export class PackageContext implements Context {
     }
   }
 
-  public addError({ file, message, longMessage, fixer }: FailureOptions) {
+  public addError({ file, message, longMessage, fixer }: AddErrorOptions) {
     this.printName();
 
     const shortFile = path.relative(this.packageDir, file);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  *
  */
 
-export { Context, Failure } from "./Context";
+export { AddErrorOptions, Context, Failure } from "./Context";
 export { Config, RuleModule, Checker, Options, ResolvedConfig, ResolvedRule, RuleEntry } from "./Config";
 export { check } from "./check";
 export { PackageContext } from "./PackageContext";


### PR DESCRIPTION
Monorepolint rules currently have to implement a synchronous `check` method. Although much of the Node.js API provides synchronous and asynchronous functions (ex: `fs.readFileSync`/`fs.readFile`), some core modules do not provide a synchronous version (e.g. `https.get`). This restricts the APIs monorepolint rules can use.

This PR focuses solely on allowing Monorepolint rules to use these asynchronous APIs. Checks and fixers are still run serially to guarantee backwards-compatible behavior. No new concurrency is attempted here.

To enable synchronous API usage, this PR:

1. Updates the `check` function on `RuleModule` to return `Promise<void>` or `void`. (It was previously just the later.)
2. Adds `Context.addErrorAsync` so `fixer` can also run asynchronously. Callers need to `await` the result of `addErrorAsync`.

I recommend reviewing commit by commit.