### PR TITLE
Properly take the intersection of ^ and >= versions when comparing peer dependencies

### DIFF
--- a/packages/rules/src/__tests__/mustSatisfyPeerDependencies.spec.ts
+++ b/packages/rules/src/__tests__/mustSatisfyPeerDependencies.spec.ts
@@ -735,6 +735,9 @@ describe("mustSatisfyPeerDependencies", () => {
       const greaterOrEqualVersion3 = ">=100";
       expect(findIntersection(majorVersion, greaterOrEqualVersion3)).toBeUndefined();
       expect(findIntersection(greaterOrEqualVersion3, majorVersion)).toBeUndefined();
+      const greaterOrEqualVersion4 = ">=15.2.3";
+      expect(findIntersection(majorVersion, greaterOrEqualVersion4)).toEqual("^15.2.3");
+      expect(findIntersection(greaterOrEqualVersion4, majorVersion)).toEqual("^15.2.3");
     });
 
     it("greater or equal vs greater or equal", () => {


### PR DESCRIPTION
In a scenario where `^16` and `>=16.2.3` are defined, the intersection of the 2 ranges is actually `^16.2.3`. Right now, this is not taken into account so the rule thinks those 2 version specifiers have no intersection.

This still doesn't take care of `~`, which the rule needs to be updated to take care of as a whole, so I only accounted for `^`.