### PR TITLE
Print out failing package name for checking alphabetical order

### DIFF
--- a/packages/rules/src/__tests__/alphabeticalScripts.spec.ts
+++ b/packages/rules/src/__tests__/alphabeticalScripts.spec.ts
@@ -15,6 +15,7 @@ import { Failure, PackageContext } from "@monorepolint/core";
 import { alphabeticalScripts } from "../alphabeticalScripts";
 
 const PACKAGE_SCRIPTS_SORTED = jsonToString({
+  name: "foo-lib",
   scripts: {
     a: "a-",
     b: "b-",
@@ -23,6 +24,7 @@ const PACKAGE_SCRIPTS_SORTED = jsonToString({
 });
 
 const PACKAGE_SCRIPTS_UNSORTED = jsonToString({
+  name: "foo-lib",
   scripts: {
     c: "c-",
     a: "a-",
@@ -58,7 +60,7 @@ describe("alphabeticalScripts", () => {
       const failure: Failure = spy.mock.calls[0][0];
       expect(failure.file).toBe("package.json");
       expect(failure.fixer).not.toBeUndefined();
-      expect(failure.message).toBe("Incorrect order of scripts in package.json");
+      expect(failure.message).toBe("Incorrect order of scripts in foo-lib's package.json");
 
       expect(mockFiles.get("package.json")).toEqual(PACKAGE_SCRIPTS_SORTED);
     });

--- a/packages/rules/src/util/checkAlpha.ts
+++ b/packages/rules/src/util/checkAlpha.ts
@@ -28,7 +28,7 @@ export function checkAlpha(
   if (!arrayOrderCompare(actualOrder, expectedOrder)) {
     context.addError({
       file: packagePath,
-      message: `Incorrect order of ${block} in package.json`,
+      message: `Incorrect order of ${block} in ${packageJson.name}'s package.json`,
       longMessage: diff(expectedOrder, actualOrder, { expand: true }),
       fixer: () => {
         const expectedDependencies: Record<string, string> = {};


### PR DESCRIPTION
Seeing the following in a monorepolint husky precommit hook is a little frustrating because it doesn't tell you _which_ package.json files you should fix, so this just updates the error message to print out the package name:

```
✖ ./node_modules/.bin/monorepolint check --paths:
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
    Error! package.json: Incorrect order of dependencies in package.json
```