### PR TITLE
Print transitive dependency path for bannedDependencies violations

### DIFF
--- a/packages/rules/src/bannedDependencies.ts
+++ b/packages/rules/src/bannedDependencies.ts
@@ -107,14 +107,14 @@ function checkTransitives(
   const graphService = new PackageDependencyGraphService();
   const root = graphService.buildDependencyGraph(path.resolve(context.getPackageJsonPath()));
   for (const { dependencies, importPath } of graphService.traverse(root)) {
-    for (const [dependency, dependencyNode] of dependencies) {
+    for (const [dependency] of dependencies) {
       if (bannedDependencies.includes(dependency)) {
         // Remove the starting package since it's obvious in CLI output.
         const [, ...importPathWithoutRoot] = importPath;
         const pathing = [...importPathWithoutRoot.map(nameOrPackageJsonPath), dependency].join(" -> ");
 
         context.addError({
-          file: dependencyNode.paths.packageJsonPath,
+          file: root.paths.packageJsonPath,
           message: `Banned transitive dependencies in repo: ${pathing}`,
         });
       }


### PR DESCRIPTION
## Changes

It's difficult to determine how banned dependencies get included from a root package. Updating this rule to print more information. Using the following config as an example:

```js
{
  options: { bannedTransitiveDependencies: ["@scope/bar"] },
  includePackages: ["@scope/foo"],
}
```

### Before

```
monorepolint (mrl) v0.5.0-alpha.68+e583f01

  @scope/foo (/packages/foo)
    Error! ../bar/package.json: Banned transitive dependencies in repo: @scope/bar
    Error! ../bar/package.json: Banned transitive dependencies in repo: @scope/bar
```

### After

```
monorepolint (mrl) v0.5.0-alpha.68+e583f01

  @scope/foo (/packages/foo)
    Error! package.json: Banned transitive dependencies in repo: @scope/baz -> @scope/quz -> @scope/zoo -> @scope/bar
    Error! package.json: Banned transitive dependencies in repo: @scope/baz -> @scope/corge -> @scope/bar
```
