### PR TITLE
add packageNameToDir to WorkspaceContext

### DIFF
--- a/packages/core/src/WorkspaceContext.ts
+++ b/packages/core/src/WorkspaceContext.ts
@@ -12,7 +12,7 @@ import { PackageContext } from "./PackageContext";
 
 // Right now, this stuff is done serially so we are writing less code to support that. Later we may want to redo this.
 export class WorkspaceContext extends PackageContext {
-  public packageNameToDir: Map<string, string> | undefined;
+  private packageNameToDir: Map<string, string> | undefined;
   constructor(packageDir: string, opts: ResolvedConfig, parent?: Context) {
     super(packageDir, opts, parent);
   }

--- a/packages/core/src/WorkspaceContext.ts
+++ b/packages/core/src/WorkspaceContext.ts
@@ -5,13 +5,14 @@
  *
  */
 
-import { getWorkspacePackageDirs } from "@monorepolint/utils";
+import { getPackageNameToDir, getWorkspacePackageDirs } from "@monorepolint/utils";
 import { ResolvedConfig } from "./Config";
 import { Context } from "./Context";
 import { PackageContext } from "./PackageContext";
 
 // Right now, this stuff is done serially so we are writing less code to support that. Later we may want to redo this.
 export class WorkspaceContext extends PackageContext {
+  public packageNameToDir: Map<string, string> | undefined;
   constructor(packageDir: string, opts: ResolvedConfig, parent?: Context) {
     super(packageDir, opts, parent);
   }
@@ -22,5 +23,10 @@ export class WorkspaceContext extends PackageContext {
 
   public createChildContext(dir: string) {
     return new PackageContext(dir, this.resolvedConfig, this);
+  }
+
+  public getPackageNameToDir() {
+    this.packageNameToDir = this.packageNameToDir ?? getPackageNameToDir(this.packageDir);
+    return this.packageNameToDir;
   }
 }

--- a/packages/rules/src/standardTsconfig.ts
+++ b/packages/rules/src/standardTsconfig.ts
@@ -6,7 +6,6 @@
  */
 
 import { Context, RuleModule } from "@monorepolint/core";
-import { getPackageNameToDir } from "@monorepolint/utils";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import diff from "jest-diff";
 import minimatch from "minimatch";
@@ -95,7 +94,7 @@ function makeGenerator(template: any, excludedReferences: ReadonlyArray<string> 
       references: [],
     }; // make a copy and ensure we have a references array
 
-    const nameToDirectory = getPackageNameToDir(context.getWorkspaceContext().packageDir);
+    const nameToDirectory = context.getWorkspaceContext().getPackageNameToDir();
 
     const packageJson = context.getPackageJson();
     const deps = [...Object.keys(packageJson.dependencies || {}), ...Object.keys(packageJson.devDependencies || {})];


### PR DESCRIPTION
add packageNameToDir to the `WorkspaceContext` to avoid recomputing for every package