### PR TITLE
Don't require workspaces field in package.json for PNPM repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,4 @@ module.exports = {
 
 ### I added a new package but I can't get it to work with the local monorepo.lint.ts. What?
 
-The way yarn workspaces function, in order to get the right symlinks in `node_modules/@monorepolint/whatever` you need to run `pnpm` again.
+The way pnpm workspaces function, in order to get the right symlinks in `node_modules/@monorepolint/whatever` you need to run `pnpm` again.

--- a/README.md
+++ b/README.md
@@ -137,15 +137,15 @@ module.exports = {
 1. Get in there:
 
    ```sh
-   yarn
-   yarn compile:watch
+   pnpm
+   pnpm compile:watch
    ```
 
 2. Edit your files
 3. Test your changes:
 
    ```sh
-   yarn ci
+   pnpm ci
    ```
 
 4. Submit a pull request
@@ -158,7 +158,7 @@ module.exports = {
 
   ```shell
   sudo gem install --pre github_changelog_generator
-  yarn run changelog
+  pnpm run changelog
   ```
 
 3. Submit a pull request
@@ -167,4 +167,4 @@ module.exports = {
 
 ### I added a new package but I can't get it to work with the local monorepo.lint.ts. What?
 
-The way yarn workspaces function, in order to get the right symlinks in `node_modules/@monorepolint/whatever` you need to run `yarn` again.
+The way yarn workspaces function, in order to get the right symlinks in `node_modules/@monorepolint/whatever` you need to run `pnpm` again.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -70,7 +70,8 @@ async function handleCheck(args: Options) {
   timing.start("Verify config");
   const config = Config.check(unverifiedConfig);
   timing.start("Resolve config");
-  const resolvedConfig = resolveConfig(config, args, findWorkspaceDir(host, process.cwd())!);
+  const workspaceDir = await findWorkspaceDir(host, process.cwd());
+  const resolvedConfig = resolveConfig(config, args, workspaceDir!);
   timing.start("Run Checks");
   const checkResult = await check(resolvedConfig, host, process.cwd(), args.paths, args.stats);
   timing.start("Flush host");

--- a/packages/core/src/WorkspaceContext.ts
+++ b/packages/core/src/WorkspaceContext.ts
@@ -19,9 +19,9 @@ export class WorkspaceContext extends PackageContext {
     super(packageDir, opts, host, parent);
   }
 
-  public getWorkspacePackageDirs() {
+  public async getWorkspacePackageDirs() {
     this.workspacePackageDirsCache =
-      this.workspacePackageDirsCache ?? getWorkspacePackageDirs(this.host, this.packageDir);
+      this.workspacePackageDirsCache ?? (await getWorkspacePackageDirs(this.host, this.packageDir));
 
     return this.workspacePackageDirsCache;
   }
@@ -30,8 +30,8 @@ export class WorkspaceContext extends PackageContext {
     return new PackageContext(dir, this.resolvedConfig, this.host, this);
   }
 
-  public getPackageNameToDir() {
-    this.packageNameToDir = this.packageNameToDir ?? getPackageNameToDir(this.host, this.packageDir);
+  public async getPackageNameToDir() {
+    this.packageNameToDir = this.packageNameToDir ?? (await getPackageNameToDir(this.host, this.packageDir));
     return this.packageNameToDir;
   }
 }

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -19,7 +19,7 @@ export async function check(
   reportStats?: boolean
 ): Promise<boolean> {
   const checkStart = process.hrtime.bigint();
-  const workspaceDir = findWorkspaceDir(host, cwd);
+  const workspaceDir = await findWorkspaceDir(host, cwd);
   if (workspaceDir === undefined) {
     throw new Error(`Unable to find a workspace from ${cwd}`);
   }

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -54,7 +54,8 @@ export async function check(
     packagesChecked++;
     await checkPackage(workspaceContext, stats);
 
-    for (const packageDir of workspaceContext.getWorkspacePackageDirs()) {
+    const workspacePackageDirs = await workspaceContext.getWorkspacePackageDirs();
+    for (const packageDir of workspacePackageDirs) {
       packagesChecked++;
       await checkPackage(workspaceContext.createChildContext(packageDir), stats);
     }

--- a/packages/rules/src/standardTsconfig.ts
+++ b/packages/rules/src/standardTsconfig.ts
@@ -41,11 +41,11 @@ const Options = r
 export type Options = r.Static<typeof Options>;
 
 export const standardTsconfig = {
-  check: function expectStandardTsconfig(context: Context, opts: Options) {
+  check: async function expectStandardTsconfig(context: Context, opts: Options) {
     const tsconfigFileName = opts.file ?? DEFAULT_TSCONFIG_FILENAME;
     const fullPath = path.resolve(context.packageDir, tsconfigFileName);
     const generator = getGenerator(context, opts);
-    const expectedContent = generator(context);
+    const expectedContent = await generator(context);
 
     const actualContent = context.host.exists(fullPath)
       ? context.host.readFile(fullPath, { encoding: "utf-8" })
@@ -97,13 +97,13 @@ function makeGenerator(
   additionalReferences: ReadonlyArray<string> | undefined,
   tsconfigReferenceFile?: string
 ) {
-  return function generator(context: Context) {
+  return async function generator(context: Context) {
     template = {
       ...template,
       references: [],
     }; // make a copy and ensure we have a references array
 
-    const nameToDirectory = context.getWorkspaceContext().getPackageNameToDir();
+    const nameToDirectory = await context.getWorkspaceContext().getPackageNameToDir();
 
     const packageJson = context.getPackageJson();
     const deps = [...Object.keys(packageJson.dependencies || {}), ...Object.keys(packageJson.devDependencies || {})];

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@pnpm/find-workspace-dir": "^3.0.3",
     "@pnpm/find-workspace-packages": "^3.1.42",
+    "@pnpm/logger": "^4.0.0",
     "glob": "^7.1.3",
     "micromatch": "^4.0.5",
     "tslib": "^2.3.1"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,6 +18,8 @@
     "test:watch": "../../node_modules/.bin/jest --colors --passWithNoTests --watch"
   },
   "dependencies": {
+    "@pnpm/find-workspace-dir": "^3.0.3",
+    "@pnpm/find-workspace-packages": "^3.1.42",
     "glob": "^7.1.3",
     "micromatch": "^4.0.5",
     "tslib": "^2.3.1"

--- a/packages/utils/src/findWorkspaceDir.ts
+++ b/packages/utils/src/findWorkspaceDir.ts
@@ -8,8 +8,19 @@
 import * as path from "path";
 import { Host } from "./Host";
 import { PackageJson } from "./PackageJson";
+import findPnpmWorkspaceDir from "@pnpm/find-workspace-dir";
 
-export function findWorkspaceDir(host: Pick<Host, "readJson" | "exists">, dir: string): string | undefined {
+export async function findWorkspaceDir(
+  host: Pick<Host, "readJson" | "exists">,
+  dir: string
+): Promise<string | undefined> {
+  // Defining workspaces in package.json is not necessary in PNPM
+  const maybePnpmWorkspaceDir = await findPnpmWorkspaceDir(dir);
+  if (maybePnpmWorkspaceDir != null) {
+    return maybePnpmWorkspaceDir;
+  }
+
+  // We may not be in a repository that uses PNPM, look for workspaces in package.json
   const packagePath = path.join(dir, "package.json");
   if (host.exists(packagePath)) {
     const packageJson = host.readJson(packagePath) as PackageJson;

--- a/packages/utils/src/getPackageNameToDir.ts
+++ b/packages/utils/src/getPackageNameToDir.ts
@@ -15,10 +15,15 @@ import { PackageJson } from "./PackageJson";
  * if `resolvePaths` is true, the returned directory names are absolute paths
  * resolved against the `workspaceDir`.
  */
-export function getPackageNameToDir(host: Pick<Host, "readJson">, workspaceDir: string, resolvePaths: boolean = false) {
+export async function getPackageNameToDir(
+  host: Pick<Host, "readJson">,
+  workspaceDir: string,
+  resolvePaths: boolean = false
+) {
   const ret = new Map<string, string>();
 
-  for (const packageDir of getWorkspacePackageDirs(host, workspaceDir, resolvePaths)) {
+  const workspacePackages = await getWorkspacePackageDirs(host, workspaceDir, resolvePaths);
+  for (const packageDir of workspacePackages) {
     const packagePath = pathJoin(packageDir, "package.json");
     const { name } = host.readJson(packagePath) as PackageJson;
     if (name === undefined) {

--- a/packages/utils/src/getWorkspacePackageDirs.ts
+++ b/packages/utils/src/getWorkspacePackageDirs.ts
@@ -7,7 +7,7 @@
 
 import { existsSync } from "fs";
 import glob from "glob";
-import path, { join as pathJoin, resolve as pathResolve } from "path";
+import { join as pathJoin, resolve as pathResolve } from "path";
 import { Host } from "./Host";
 import { PackageJson } from "./PackageJson";
 import findPNPMWorkspacePackages from "@pnpm/find-workspace-packages";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,7 @@ importers:
     specifiers:
       '@pnpm/find-workspace-dir': ^3.0.3
       '@pnpm/find-workspace-packages': ^3.1.42
+      '@pnpm/logger': ^4.0.0
       '@types/glob': ^7.1.1
       '@types/micromatch': ^2.3.31
       '@types/node': ^14.0.12
@@ -145,7 +146,8 @@ importers:
       tslib: ^2.3.1
     dependencies:
       '@pnpm/find-workspace-dir': 3.0.3
-      '@pnpm/find-workspace-packages': 3.1.53
+      '@pnpm/find-workspace-packages': 3.1.53_@pnpm+logger@4.0.0
+      '@pnpm/logger': 4.0.0
       glob: registry.npmjs.org/glob/7.2.0
       micromatch: registry.npmjs.org/micromatch/4.0.5
       tslib: registry.npmjs.org/tslib/2.4.0
@@ -223,25 +225,26 @@ packages:
       load-json-file: 6.2.0
     dev: false
 
-  /@pnpm/cli-utils/0.6.61:
+  /@pnpm/cli-utils/0.6.61_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-6RBPadEYZKEOo0tKHisO/xnClF9l2B6yEOAEGZtZDrXSmAQHkmrLe64UPEjmhGKuEowMAX+3lmJSC/0DWFfb4w==}
     engines: {node: '>=12.17'}
     peerDependencies:
       '@pnpm/logger': ^4.0.0
     dependencies:
       '@pnpm/cli-meta': 2.0.3
-      '@pnpm/config': 13.14.2
-      '@pnpm/default-reporter': 8.6.3
+      '@pnpm/config': 13.14.2_@pnpm+logger@4.0.0
+      '@pnpm/default-reporter': 8.6.3_@pnpm+logger@4.0.0
       '@pnpm/error': 2.1.0
-      '@pnpm/manifest-utils': 2.1.11
-      '@pnpm/package-is-installable': 5.0.14
+      '@pnpm/logger': 4.0.0
+      '@pnpm/manifest-utils': 2.1.11_@pnpm+logger@4.0.0
+      '@pnpm/package-is-installable': 5.0.14_@pnpm+logger@4.0.0
       '@pnpm/read-project-manifest': 2.0.14
       '@pnpm/types': 7.11.0
       chalk: 4.1.2
       load-json-file: 6.2.0
     dev: false
 
-  /@pnpm/config/13.14.2:
+  /@pnpm/config/13.14.2_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-jy4LPqqJADaMNvC0UHLjcrGDatUO/mUxaiv95ClHeZTcFXriaeG84HtzYGOIWU29ysv+XXMHMMdCQzDoAgkGHw==}
     engines: {node: '>=12.17'}
     dependencies:
@@ -249,7 +252,7 @@ packages:
       '@pnpm/error': 2.1.0
       '@pnpm/global-bin-dir': 3.0.1
       '@pnpm/npm-conf': 1.0.4
-      '@pnpm/pnpmfile': 1.2.7
+      '@pnpm/pnpmfile': 1.2.7_@pnpm+logger@4.0.0
       '@pnpm/read-project-manifest': 2.0.14
       '@pnpm/types': 7.11.0
       camelcase: 6.3.0
@@ -268,24 +271,26 @@ packages:
     engines: {node: '>=12.17'}
     dev: false
 
-  /@pnpm/core-loggers/6.1.5:
+  /@pnpm/core-loggers/6.1.5_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-tIpC0xvHa0vihzUm0VJ/FAHNZKGcxxhQDoCk+PUCJ9v9ZLAaFQiGEmwya03Ei0Gy+btURC1yRQmZRBXuRGj5rQ==}
     engines: {node: '>=12.17'}
     peerDependencies:
       '@pnpm/logger': ^4.0.0
     dependencies:
+      '@pnpm/logger': 4.0.0
       '@pnpm/types': 7.11.0
     dev: false
 
-  /@pnpm/default-reporter/8.6.3:
+  /@pnpm/default-reporter/8.6.3_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-5e/cg+V7+FdtbShCr9h6YSYIrG6KyxIM3kJIsLguNPpRydoS/uoAA+lZCaa2wL3gspC2hmFhJVnzFgHEQrbLQA==}
     engines: {node: '>=12.17'}
     peerDependencies:
       '@pnpm/logger': ^4.0.0
     dependencies:
-      '@pnpm/config': 13.14.2
-      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/config': 13.14.2_@pnpm+logger@4.0.0
+      '@pnpm/core-loggers': 6.1.5_@pnpm+logger@4.0.0
       '@pnpm/error': 2.1.0
+      '@pnpm/logger': 4.0.0
       '@pnpm/render-peer-issues': 1.1.3
       '@pnpm/types': 7.11.0
       ansi-diff: 1.1.1
@@ -318,11 +323,11 @@ packages:
       find-up: 5.0.0
     dev: false
 
-  /@pnpm/find-workspace-packages/3.1.53:
+  /@pnpm/find-workspace-packages/3.1.53_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-WTimFwEM33e37aCjhJuwzBocGRL24f9m7OMjQ6/YEHZIIc6IJd17FxAtp+eXW/rRrbttZ8oM7fuRjDPz43bfDQ==}
     engines: {node: '>=12.17'}
     dependencies:
-      '@pnpm/cli-utils': 0.6.61
+      '@pnpm/cli-utils': 0.6.61_@pnpm+logger@4.0.0
       '@pnpm/constants': 5.0.0
       '@pnpm/types': 7.11.0
       find-packages: 8.0.14
@@ -354,11 +359,19 @@ packages:
       '@pnpm/types': 7.11.0
     dev: false
 
-  /@pnpm/manifest-utils/2.1.11:
+  /@pnpm/logger/4.0.0:
+    resolution: {integrity: sha512-SIShw+k556e7S7tLZFVSIHjCdiVog1qWzcKW2RbLEHPItdisAFVNIe34kYd9fMSswTlSRLS/qRjw3ZblzWmJ9Q==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      bole: 4.0.0
+      ndjson: 2.0.0
+    dev: false
+
+  /@pnpm/manifest-utils/2.1.11_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-V3YdTThC2ZnDAkKmdA0682l5nmp37S/OB0YWDeBEkDSHPNPzsGyfIMp4UcqJJ5Yg+VHhxVmkTgPFMAQ8Z9RWgw==}
     engines: {node: '>=12.17'}
     dependencies:
-      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/core-loggers': 6.1.5_@pnpm+logger@4.0.0
       '@pnpm/error': 2.1.0
       '@pnpm/types': 7.11.0
     transitivePeerDependencies:
@@ -380,29 +393,31 @@ packages:
       config-chain: 1.1.13
     dev: false
 
-  /@pnpm/package-is-installable/5.0.14:
+  /@pnpm/package-is-installable/5.0.14_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-XDMRaSy+byrDn2m38Mtvmpvhc/BtEM21Csf7JptxgQ654lNeclPnjp+z3VnL3Qc2peA+3UbwDwF5q6fmRZKY9g==}
     engines: {node: '>=12.17'}
     peerDependencies:
       '@pnpm/logger': ^4.0.0
     dependencies:
-      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/core-loggers': 6.1.5_@pnpm+logger@4.0.0
       '@pnpm/error': 2.1.0
+      '@pnpm/logger': 4.0.0
       '@pnpm/types': 7.11.0
       execa: /safe-execa/0.1.1
       mem: 8.1.1
       semver: 7.3.7
     dev: false
 
-  /@pnpm/pnpmfile/1.2.7:
+  /@pnpm/pnpmfile/1.2.7_@pnpm+logger@4.0.0:
     resolution: {integrity: sha512-NjQirXo7JtKBzew+SIw5/dw+FVPXPL8IHpAX0ukakptGmGZrNfHdLHikWiCg2uS6SzuTjeQcArqdnMM3t+jdZA==}
     engines: {node: '>=12.17'}
     peerDependencies:
       '@pnpm/logger': ^4.0.0
     dependencies:
-      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/core-loggers': 6.1.5_@pnpm+logger@4.0.0
       '@pnpm/error': 2.1.0
       '@pnpm/lockfile-types': 3.2.1
+      '@pnpm/logger': 4.0.0
       '@pnpm/types': 7.11.0
       chalk: 4.1.2
       path-absolute: 1.0.1
@@ -541,6 +556,13 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       is-windows: 1.0.2
+    dev: false
+
+  /bole/4.0.0:
+    resolution: {integrity: sha512-Bk/2qoyOSlwU1dnDFk/oPM2FCNKAlYlBHfpAgwGX+K9HUtxSvmIAQCmMWMOvE6BlHHRCwsH1MxJe/r1ieodxqQ==}
+    dependencies:
+      fast-safe-stringify: 2.1.1
+      individual: 3.0.0
     dev: false
 
   /boxen/5.1.2:
@@ -719,6 +741,10 @@ packages:
       micromatch: 4.0.5
     dev: false
 
+  /fast-safe-stringify/2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: false
+
   /fastq/1.8.0:
     resolution: {integrity: sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==}
     dependencies:
@@ -798,6 +824,14 @@ packages:
     engines: {node: '>=0.8.19'}
     dev: false
 
+  /individual/3.0.0:
+    resolution: {integrity: sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==}
+    dev: false
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
   /ini/1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: false
@@ -870,6 +904,10 @@ packages:
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: false
+
+  /json-stringify-safe/5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: false
 
   /json5/2.2.1:
@@ -953,6 +991,22 @@ packages:
   /mimic-fn/3.1.0:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
+    dev: false
+
+  /minimist/1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: false
+
+  /ndjson/2.0.0:
+    resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      json-stringify-safe: 5.0.1
+      minimist: 1.2.6
+      readable-stream: 3.6.0
+      split2: 3.2.2
+      through2: 4.0.2
     dev: false
 
   /normalize-path/3.0.0:
@@ -1104,6 +1158,15 @@ packages:
       strip-bom: 4.0.0
     dev: false
 
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: false
+
   /realpath-missing/1.1.0:
     resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
     engines: {node: '>=10'}
@@ -1127,6 +1190,10 @@ packages:
     resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
     dependencies:
       tslib: 2.4.0
+    dev: false
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: false
 
   /safe-execa/0.1.1:
@@ -1173,6 +1240,12 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  /split2/3.2.2:
+    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
+    dependencies:
+      readable-stream: 3.6.0
+    dev: false
+
   /stacktracey/2.1.8:
     resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
     dependencies:
@@ -1195,6 +1268,12 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+    dev: false
+
+  /string_decoder/1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
     dev: false
 
   /strip-ansi/6.0.1:
@@ -1226,6 +1305,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
+    dev: false
+
+  /through2/4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
+    dependencies:
+      readable-stream: 3.6.0
     dev: false
 
   /to-regex-range/5.0.1:
@@ -1268,6 +1353,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       crypto-random-string: 2.0.0
+    dev: false
+
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: false
 
   /which/2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       tslint: ^6.1.2
       typescript: ^4.6.3
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/2.3.2
+      fsevents: 2.3.2
     devDependencies:
       '@monorepolint/cli': link:packages/cli
       '@monorepolint/rules': link:packages/rules
@@ -135,6 +135,8 @@ importers:
 
   packages/utils:
     specifiers:
+      '@pnpm/find-workspace-dir': ^3.0.3
+      '@pnpm/find-workspace-packages': ^3.1.42
       '@types/glob': ^7.1.1
       '@types/micromatch': ^2.3.31
       '@types/node': ^14.0.12
@@ -142,6 +144,8 @@ importers:
       micromatch: ^4.0.5
       tslib: ^2.3.1
     dependencies:
+      '@pnpm/find-workspace-dir': 3.0.3
+      '@pnpm/find-workspace-packages': 3.1.53
       glob: registry.npmjs.org/glob/7.2.0
       micromatch: registry.npmjs.org/micromatch/4.0.5
       tslib: registry.npmjs.org/tslib/2.4.0
@@ -151,6 +155,1170 @@ importers:
       '@types/node': registry.npmjs.org/@types/node/14.0.13
 
 packages:
+
+  /@babel/code-frame/7.16.7:
+    resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.16.10
+    dev: false
+
+  /@babel/helper-validator-identifier/7.16.7:
+    resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/highlight/7.16.10:
+    resolution: {integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: false
+
+  /@colors/colors/1.5.0:
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@docusaurus/react-loadable/5.5.2_react@16.13.1:
+    resolution: {integrity: sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      '@types/react': 18.0.8
+      prop-types: 15.7.2
+      react: registry.npmjs.org/react/16.13.1
+    dev: false
+
+  /@nodelib/fs.scandir/2.1.3:
+    resolution: {integrity: sha1-Olgr21OATGum0UZXnEblITDPSjs=}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.3
+      run-parallel: 1.1.9
+    dev: false
+
+  /@nodelib/fs.stat/2.0.3:
+    resolution: {integrity: sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /@nodelib/fs.walk/1.2.4:
+    resolution: {integrity: sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.3
+      fastq: 1.8.0
+    dev: false
+
+  /@pnpm/cli-meta/2.0.3:
+    resolution: {integrity: sha512-VPekfwCV39lF2dShE2+eHFrzU8Qxbqo+TEevU5BEoZG0K1zXxhfw6VyBbIC2+C1YbutJXQPYDVJQCGPhyRtNqA==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/types': 7.11.0
+      load-json-file: 6.2.0
+    dev: false
+
+  /@pnpm/cli-utils/0.6.61:
+    resolution: {integrity: sha512-6RBPadEYZKEOo0tKHisO/xnClF9l2B6yEOAEGZtZDrXSmAQHkmrLe64UPEjmhGKuEowMAX+3lmJSC/0DWFfb4w==}
+    engines: {node: '>=12.17'}
+    peerDependencies:
+      '@pnpm/logger': ^4.0.0
+    dependencies:
+      '@pnpm/cli-meta': 2.0.3
+      '@pnpm/config': 13.14.2
+      '@pnpm/default-reporter': 8.6.3
+      '@pnpm/error': 2.1.0
+      '@pnpm/manifest-utils': 2.1.11
+      '@pnpm/package-is-installable': 5.0.14
+      '@pnpm/read-project-manifest': 2.0.14
+      '@pnpm/types': 7.11.0
+      chalk: 4.1.2
+      load-json-file: 6.2.0
+    dev: false
+
+  /@pnpm/config/13.14.2:
+    resolution: {integrity: sha512-jy4LPqqJADaMNvC0UHLjcrGDatUO/mUxaiv95ClHeZTcFXriaeG84HtzYGOIWU29ysv+XXMHMMdCQzDoAgkGHw==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/constants': 5.0.0
+      '@pnpm/error': 2.1.0
+      '@pnpm/global-bin-dir': 3.0.1
+      '@pnpm/npm-conf': 1.0.4
+      '@pnpm/pnpmfile': 1.2.7
+      '@pnpm/read-project-manifest': 2.0.14
+      '@pnpm/types': 7.11.0
+      camelcase: 6.3.0
+      can-write-to-dir: 1.1.1
+      is-subdir: 1.2.0
+      normalize-registry-url: 2.0.0
+      ramda: 0.27.2
+      realpath-missing: 1.1.0
+      which: 2.0.2
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+    dev: false
+
+  /@pnpm/constants/5.0.0:
+    resolution: {integrity: sha512-VhUGKR5jvAtoBHgHAB3Kfc9g42ocVUws9iOafGAQ+xjR8uLokUCReXDpLXRRtrqw8N8yyh3gLNpCJs/AYadA1g==}
+    engines: {node: '>=12.17'}
+    dev: false
+
+  /@pnpm/core-loggers/6.1.5:
+    resolution: {integrity: sha512-tIpC0xvHa0vihzUm0VJ/FAHNZKGcxxhQDoCk+PUCJ9v9ZLAaFQiGEmwya03Ei0Gy+btURC1yRQmZRBXuRGj5rQ==}
+    engines: {node: '>=12.17'}
+    peerDependencies:
+      '@pnpm/logger': ^4.0.0
+    dependencies:
+      '@pnpm/types': 7.11.0
+    dev: false
+
+  /@pnpm/default-reporter/8.6.3:
+    resolution: {integrity: sha512-5e/cg+V7+FdtbShCr9h6YSYIrG6KyxIM3kJIsLguNPpRydoS/uoAA+lZCaa2wL3gspC2hmFhJVnzFgHEQrbLQA==}
+    engines: {node: '>=12.17'}
+    peerDependencies:
+      '@pnpm/logger': ^4.0.0
+    dependencies:
+      '@pnpm/config': 13.14.2
+      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/error': 2.1.0
+      '@pnpm/render-peer-issues': 1.1.3
+      '@pnpm/types': 7.11.0
+      ansi-diff: 1.1.1
+      boxen: 5.1.2
+      chalk: 4.1.2
+      normalize-path: 3.0.0
+      pretty-bytes: 5.6.0
+      pretty-ms: 7.0.1
+      ramda: 0.27.2
+      right-pad: 1.0.1
+      rxjs: 7.5.5
+      semver: 7.3.7
+      stacktracey: 2.1.8
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+    dev: false
+
+  /@pnpm/error/2.1.0:
+    resolution: {integrity: sha512-IxtPG61WgxsDNbtWW+128RiRo6WHhm7Dm2vm77xxC/zEi/uQ35Uf59olhVT3m2/ETDw/iz7Lv1RpvPYTsglX9g==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/constants': 5.0.0
+    dev: false
+
+  /@pnpm/find-workspace-dir/3.0.3:
+    resolution: {integrity: sha512-BKYs+FNdsGNce2H71abpbeQN8gKviAyF/ue9UdZktMgzKfZGQFhQ+qRssWY3+2CaaSoIRxftXdylkaRALsxlBw==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/error': 2.1.0
+      find-up: 5.0.0
+    dev: false
+
+  /@pnpm/find-workspace-packages/3.1.53:
+    resolution: {integrity: sha512-WTimFwEM33e37aCjhJuwzBocGRL24f9m7OMjQ6/YEHZIIc6IJd17FxAtp+eXW/rRrbttZ8oM7fuRjDPz43bfDQ==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/cli-utils': 0.6.61
+      '@pnpm/constants': 5.0.0
+      '@pnpm/types': 7.11.0
+      find-packages: 8.0.14
+      read-yaml-file: 2.1.0
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+    dev: false
+
+  /@pnpm/global-bin-dir/3.0.1:
+    resolution: {integrity: sha512-BVAi5ezLB4ex86MjEB//GuUDiwsVDBWbdZurg3XWGkoLbwmasqC8OME7Uh1VrPqKuTYPulsE04mOQtLw5rlF9A==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/error': 2.1.0
+      can-write-to-dir: 1.1.1
+      path-name: 1.0.0
+    dev: false
+
+  /@pnpm/graceful-fs/1.0.0:
+    resolution: {integrity: sha512-bb+NcVgVBjm81skP73c0i4o2NUxiBt0d30KLXHJ05EejQ/qbxQMsi/gZxsi8MKbzCky2DzykQYkzm2tl3XajAQ==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      graceful-fs: 4.2.10
+    dev: false
+
+  /@pnpm/lockfile-types/3.2.1:
+    resolution: {integrity: sha512-d6E84PHjz6yDW1YXmbGeyaPVGOBuCBLQO2XTvtnJyBJyKtQk6cCdeu7hBNNbXklGlCtoJ108a1nRDldXRTwdYA==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/types': 7.11.0
+    dev: false
+
+  /@pnpm/manifest-utils/2.1.11:
+    resolution: {integrity: sha512-V3YdTThC2ZnDAkKmdA0682l5nmp37S/OB0YWDeBEkDSHPNPzsGyfIMp4UcqJJ5Yg+VHhxVmkTgPFMAQ8Z9RWgw==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/error': 2.1.0
+      '@pnpm/types': 7.11.0
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+    dev: false
+
+  /@pnpm/network.ca-file/1.0.1:
+    resolution: {integrity: sha512-gkINruT2KUhZLTaiHxwCOh1O4NVnFT0wLjWFBHmTz9vpKag/C/noIMJXBxFe4F0mYpUVX2puLwAieLYFg2NvoA==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      graceful-fs: 4.2.10
+    dev: false
+
+  /@pnpm/npm-conf/1.0.4:
+    resolution: {integrity: sha512-o5YFq/+ksEJMbSzzkaQDHlp00aonLDU5xNPVTRL12hTWBbVSSeWXxPukq75h+mvXnoOWT95vV2u1HSTw2C4XOw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@pnpm/network.ca-file': 1.0.1
+      config-chain: 1.1.13
+    dev: false
+
+  /@pnpm/package-is-installable/5.0.14:
+    resolution: {integrity: sha512-XDMRaSy+byrDn2m38Mtvmpvhc/BtEM21Csf7JptxgQ654lNeclPnjp+z3VnL3Qc2peA+3UbwDwF5q6fmRZKY9g==}
+    engines: {node: '>=12.17'}
+    peerDependencies:
+      '@pnpm/logger': ^4.0.0
+    dependencies:
+      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/error': 2.1.0
+      '@pnpm/types': 7.11.0
+      execa: /safe-execa/0.1.1
+      mem: 8.1.1
+      semver: 7.3.7
+    dev: false
+
+  /@pnpm/pnpmfile/1.2.7:
+    resolution: {integrity: sha512-NjQirXo7JtKBzew+SIw5/dw+FVPXPL8IHpAX0ukakptGmGZrNfHdLHikWiCg2uS6SzuTjeQcArqdnMM3t+jdZA==}
+    engines: {node: '>=12.17'}
+    peerDependencies:
+      '@pnpm/logger': ^4.0.0
+    dependencies:
+      '@pnpm/core-loggers': 6.1.5
+      '@pnpm/error': 2.1.0
+      '@pnpm/lockfile-types': 3.2.1
+      '@pnpm/types': 7.11.0
+      chalk: 4.1.2
+      path-absolute: 1.0.1
+    dev: false
+
+  /@pnpm/read-project-manifest/2.0.14:
+    resolution: {integrity: sha512-eeD5FwvH76D3y5YNqHVnKfkJx0PHjQTZ6PvWg8xxG3+NDX4fYqnabJW7RvuQLrIRtAogLOk/7H35gVRAFfxCHA==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/error': 2.1.0
+      '@pnpm/graceful-fs': 1.0.0
+      '@pnpm/types': 7.11.0
+      '@pnpm/write-project-manifest': 2.0.12
+      detect-indent: 6.1.0
+      fast-deep-equal: 3.1.3
+      is-windows: 1.0.2
+      json5: 2.2.1
+      parse-json: 5.2.0
+      read-yaml-file: 2.1.0
+      sort-keys: 4.2.0
+      strip-bom: 4.0.0
+    dev: false
+
+  /@pnpm/render-peer-issues/1.1.3:
+    resolution: {integrity: sha512-MbICxpU3DECNIsKw3ZIbRL+l5WlC67Ci2SjButR39RQA3RYamGuZQmlQ5jOZ58ZO+JV+66zLeEfD2+mI+2VL+Q==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/types': 7.11.0
+      archy: 1.0.0
+      chalk: 4.1.2
+      cli-columns: 4.0.0
+    dev: false
+
+  /@pnpm/types/7.11.0:
+    resolution: {integrity: sha512-q7vABFn0vt7kxvYdBP/4L/ExtH05yG6iU08VrmdA9fvRsxtXC8H59tavZG9Tg0qaMlEgfPmEQ0yutGsR5TjG5A==}
+    engines: {node: '>=12.17'}
+    dev: false
+
+  /@pnpm/write-project-manifest/2.0.12:
+    resolution: {integrity: sha512-QH63aLC6OOtUx0LNpkO9LU0XgXLje2EpVptWS3w0Wg4hAYDeEvBy/h3Ku6WTX1SA+9WtnjpQp68vw9pyajO4gw==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/types': 7.11.0
+      json5: 2.2.1
+      write-file-atomic: 3.0.3
+      write-yaml-file: 4.2.0
+    dev: false
+
+  /@types/color-name/1.1.1:
+    resolution: {integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==}
+    dev: false
+
+  /@types/prop-types/15.7.5:
+    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+    dev: false
+
+  /@types/react/18.0.8:
+    resolution: {integrity: sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.11
+    dev: false
+
+  /@types/scheduler/0.16.2:
+    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
+    dev: false
+
+  /@zkochan/which/2.0.3:
+    resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: false
+
+  /ansi-align/3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+    dependencies:
+      string-width: 4.2.3
+    dev: false
+
+  /ansi-diff/1.1.1:
+    resolution: {integrity: sha512-XnTdFDQzbEewrDx8epWXdw7oqHMvv315vEtfqDiEhhWghIf4++h26c3/FMz7iTLhNrnj56DNIXpbxHZq+3s6qw==}
+    dependencies:
+      ansi-split: 1.0.1
+    dev: false
+
+  /ansi-regex/3.0.1:
+    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /ansi-regex/5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /ansi-split/1.0.1:
+    resolution: {integrity: sha512-RRxQym4DFtDNmHIkW6aeFVvrXURb11lGAEPXNiryjCe8bK8RsANjzJ0M2aGOkvBYwP4Bl/xZ8ijtr6D3j1x/eg==}
+    dependencies:
+      ansi-regex: 3.0.1
+    dev: false
+
+  /ansi-styles/3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: false
+
+  /ansi-styles/4.2.1:
+    resolution: {integrity: sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/color-name': 1.1.1
+      color-convert: 2.0.1
+    dev: false
+
+  /archy/1.0.0:
+    resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
+    dev: false
+
+  /argparse/2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: false
+
+  /as-table/1.0.55:
+    resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+    dependencies:
+      printable-characters: 1.0.42
+    dev: false
+
+  /better-path-resolve/1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
+    dependencies:
+      is-windows: 1.0.2
+    dev: false
+
+  /boxen/5.1.2:
+    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      cli-boxes: 2.2.1
+      string-width: 4.2.3
+      type-fest: 0.20.2
+      widest-line: 3.1.0
+      wrap-ansi: 7.0.0
+    dev: false
+
+  /braces/3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+    dev: false
+
+  /camelcase/6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /can-write-to-dir/1.1.1:
+    resolution: {integrity: sha512-eOgiEWqjppB+3DN/5E82EQ8dTINus8d9GXMCbEsUnp2hcUIcXmBvzWmD3tXMk3CuBK0v+ddK9qw0EAF+JVRMjQ==}
+    engines: {node: '>=10.13'}
+    dependencies:
+      path-temp: 2.0.0
+    dev: false
+
+  /chalk/2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: false
+
+  /chalk/4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.2.1
+      supports-color: 7.1.0
+    dev: false
+
+  /char-regex/1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /cli-boxes/2.2.1:
+    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /cli-columns/4.0.0:
+    resolution: {integrity: sha512-XW2Vg+w+L9on9wtwKpyzluIPCWXjaBahI7mTcYjx+BVIYD9c3yqcv/yKC7CmdCZat4rq2yiE1UMSJC5ivKfMtQ==}
+    engines: {node: '>= 10'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: false
+
+  /color-convert/1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: false
+
+  /color-convert/2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: false
+
+  /color-name/1.1.3:
+    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
+    dev: false
+
+  /color-name/1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: false
+
+  /config-chain/1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+    dev: false
+
+  /cross-spawn/7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: false
+
+  /crypto-random-string/2.0.0:
+    resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /csstype/3.0.11:
+    resolution: {integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==}
+    dev: false
+
+  /data-uri-to-buffer/2.0.2:
+    resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
+    dev: false
+
+  /detect-indent/6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /emoji-regex/8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: false
+
+  /encoding/0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    requiresBuild: true
+    dependencies:
+      iconv-lite: registry.npmjs.org/iconv-lite/0.6.3
+    dev: true
+    optional: true
+
+  /error-ex/1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: false
+
+  /escape-string-regexp/1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+    dev: false
+
+  /execa/5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+    dev: false
+
+  /fast-deep-equal/3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+
+  /fast-glob/3.2.11:
+    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.3
+      '@nodelib/fs.walk': 1.2.4
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: false
+
+  /fastq/1.8.0:
+    resolution: {integrity: sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==}
+    dependencies:
+      reusify: 1.0.4
+    dev: false
+
+  /fill-range/7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: false
+
+  /find-packages/8.0.14:
+    resolution: {integrity: sha512-1CPA/n7ENTTrpVczSXIwL1CiDYDb/ZgDDEeR/9XWv+eugulhOqRYy1yHNSWqiTgMuqNqmewx/x/fkDNbjrPKMA==}
+    engines: {node: '>=12.17'}
+    dependencies:
+      '@pnpm/read-project-manifest': 2.0.14
+      '@pnpm/types': 7.11.0
+      fast-glob: 3.2.11
+      p-filter: 2.1.0
+    dev: false
+
+  /find-up/5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+    dev: false
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    requiresBuild: true
+    optional: true
+
+  /get-source/2.0.12:
+    resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+    dependencies:
+      data-uri-to-buffer: 2.0.2
+      source-map: 0.6.1
+    dev: false
+
+  /get-stream/6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: false
+
+  /graceful-fs/4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
+  /has-flag/3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /has-flag/4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /human-signals/2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+    dev: false
+
+  /imurmurhash/0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+    dev: false
+
+  /ini/1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: false
+
+  /is-arrayish/0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: false
+
+  /is-extglob/2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-fullwidth-code-point/3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /is-glob/4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: false
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  /is-plain-obj/2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /is-stream/2.0.0:
+    resolution: {integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /is-subdir/1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+    dependencies:
+      better-path-resolve: 1.0.0
+    dev: false
+
+  /is-typedarray/1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+    dev: false
+
+  /is-windows/1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /isexe/2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: false
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: false
+
+  /js-yaml/4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+    dev: false
+
+  /json-parse-even-better-errors/2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: false
+
+  /json5/2.2.1:
+    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: false
+
+  /lines-and-columns/1.1.6:
+    resolution: {integrity: sha512-8ZmlJFVK9iCmtLz19HpSsR8HaAMWBT284VMNednLwlIMDP2hJDCIhUp0IZ2xUcZ+Ob6BM0VvCSJwzASDM45NLQ==}
+    dev: false
+
+  /load-json-file/6.2.0:
+    resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      graceful-fs: 4.2.10
+      parse-json: 5.2.0
+      strip-bom: 4.0.0
+      type-fest: 0.6.0
+    dev: false
+
+  /locate-path/6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-locate: 5.0.0
+    dev: false
+
+  /loose-envify/1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
+  /lru-cache/6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
+  /map-age-cleaner/0.1.3:
+    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-defer: 1.0.0
+    dev: false
+
+  /mem/8.1.1:
+    resolution: {integrity: sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==}
+    engines: {node: '>=10'}
+    dependencies:
+      map-age-cleaner: 0.1.3
+      mimic-fn: 3.1.0
+    dev: false
+
+  /merge-stream/2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: false
+
+  /merge2/1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /micromatch/4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: false
+
+  /mimic-fn/2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /mimic-fn/3.1.0:
+    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /normalize-registry-url/2.0.0:
+    resolution: {integrity: sha512-3e9FwDyRAhbxXw4slm4Tjv40u78yPwMc/WZkACpqNQOs5sM7wic853AeTLkMFEVhivZkclGYlse8iYsklz0Yvg==}
+    dev: false
+
+  /npm-run-path/4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-key: 3.1.1
+    dev: false
+
+  /object-assign/4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /onetime/5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+    dependencies:
+      mimic-fn: 2.1.0
+    dev: false
+
+  /p-defer/1.0.0:
+    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /p-filter/2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-map: 2.1.0
+    dev: false
+
+  /p-limit/3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      yocto-queue: 0.1.0
+    dev: false
+
+  /p-locate/5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-limit: 3.1.0
+    dev: false
+
+  /p-map/2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /parse-json/5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.1.6
+    dev: false
+
+  /parse-ms/2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /path-absolute/1.0.1:
+    resolution: {integrity: sha512-gds5iRhSeOcDtj8gfWkRHLtZKTPsFVuh7utbjYtvnclw4XM+ffRzJrwqMhOD1PVqef7nBLmgsu1vIujjvAJrAw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /path-exists/4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /path-key/3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /path-name/1.0.0:
+    resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==}
+    dev: false
+
+  /path-temp/2.0.0:
+    resolution: {integrity: sha512-92olbatybjsHTGB2CUnAM7s0mU/27gcMfLNA7t09UftndUdxywlQKur3fzXEPpfLrgZD3I2Bt8+UmiL7YDEgXQ==}
+    engines: {node: '>=8.15'}
+    dependencies:
+      unique-string: 2.0.0
+    dev: false
+
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: false
+
+  /pretty-bytes/5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /pretty-ms/7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      parse-ms: 2.1.0
+    dev: false
+
+  /printable-characters/1.0.42:
+    resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
+    dev: false
+
+  /prop-types/15.7.2:
+    resolution: {integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+    dev: false
+
+  /proto-list/1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+    dev: false
+
+  /ramda/0.27.2:
+    resolution: {integrity: sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==}
+    dev: false
+
+  /react-is/16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    dev: false
+
+  /read-yaml-file/2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
+    dependencies:
+      js-yaml: 4.1.0
+      strip-bom: 4.0.0
+    dev: false
+
+  /realpath-missing/1.1.0:
+    resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /reusify/1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: false
+
+  /right-pad/1.0.1:
+    resolution: {integrity: sha512-bYBjgxmkvTAfgIYy328fmkwhp39v8lwVgWhhrzxPV3yHtcSqyYKe9/XOhvW48UFjATg3VuJbpsp5822ACNvkmw==}
+    engines: {node: '>= 0.10'}
+    dev: false
+
+  /run-parallel/1.1.9:
+    resolution: {integrity: sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==}
+    dev: false
+
+  /rxjs/7.5.5:
+    resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
+  /safe-execa/0.1.1:
+    resolution: {integrity: sha512-2KPID7iC4AMoJVozDPtcLGV+7LdpE0sR1hPkJUCaEnRsiYSZH2wgOFvxZ9UOtj1r8hNk8pVWn1tgmaEyyFZ4NA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@zkochan/which': 2.0.3
+      execa: 5.1.1
+      path-name: 1.0.0
+    dev: false
+
+  /semver/7.3.7:
+    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
+  /shebang-command/2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: false
+
+  /shebang-regex/3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /signal-exit/3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: false
+
+  /sort-keys/4.2.0:
+    resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-plain-obj: 2.1.0
+    dev: false
+
+  /source-map/0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  /stacktracey/2.1.8:
+    resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
+    dependencies:
+      as-table: 1.0.55
+      get-source: 2.0.12
+    dev: false
+
+  /string-length/4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+    dev: false
+
+  /string-width/4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: false
+
+  /strip-ansi/6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: false
+
+  /strip-bom/4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /strip-final-newline/2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /supports-color/5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+    dev: false
+
+  /supports-color/7.1.0:
+    resolution: {integrity: sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: false
+
+  /to-regex-range/5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: false
+
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: false
+
+  /type-fest/0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /type-fest/0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /typedarray-to-buffer/3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+    dependencies:
+      is-typedarray: 1.0.0
+    dev: false
+
+  /uglify-js/3.15.4:
+    resolution: {integrity: sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /unique-string/2.0.0:
+    resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
+    engines: {node: '>=8'}
+    dependencies:
+      crypto-random-string: 2.0.0
+    dev: false
+
+  /which/2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: false
+
+  /widest-line/3.1.0:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
+    engines: {node: '>=8'}
+    dependencies:
+      string-width: 4.2.3
+    dev: false
+
+  /wrap-ansi/7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.2.1
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: false
+
+  /write-file-atomic/3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+    dependencies:
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
+    dev: false
+
+  /write-yaml-file/4.2.0:
+    resolution: {integrity: sha512-LwyucHy0uhWqbrOkh9cBluZBeNVxzHjDaE9mwepZG3n3ZlbM4v3ndrFw51zW/NXYFFqP+QWZ72ihtLWTh05e4Q==}
+    engines: {node: '>=10.13'}
+    dependencies:
+      js-yaml: 4.1.0
+      write-file-atomic: 3.0.3
+    dev: false
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: false
+
+  /yocto-queue/0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+    dev: false
 
   registry.npmjs.org/@algolia/autocomplete-core/1.5.2:
     resolution: {integrity: sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz}
@@ -1954,15 +3122,6 @@ packages:
     version: 0.2.3
     dev: true
 
-  registry.npmjs.org/@colors/colors/1.5.0:
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz}
-    name: '@colors/colors'
-    version: 1.5.0
-    engines: {node: '>=0.1.90'}
-    requiresBuild: true
-    dev: false
-    optional: true
-
   registry.npmjs.org/@cspotcode/source-map-consumer/0.8.0:
     resolution: {integrity: sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz}
     name: '@cspotcode/source-map-consumer'
@@ -2071,7 +3230,7 @@ packages:
       react-dev-utils: registry.npmjs.org/react-dev-utils/12.0.1_typescript@4.6.3+webpack@5.72.0
       react-dom: registry.npmjs.org/react-dom/16.13.1_react@16.13.1
       react-helmet-async: registry.npmjs.org/react-helmet-async/1.3.0_react-dom@16.13.1+react@16.13.1
-      react-loadable: registry.npmjs.org/@docusaurus/react-loadable/5.5.2_react@16.13.1
+      react-loadable: /@docusaurus/react-loadable/5.5.2_react@16.13.1
       react-loadable-ssr-addon-v5-slorber: registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/1.0.1_e9a32d0ed12f8f09954f994457231c0d
       react-router: registry.npmjs.org/react-router/5.3.1_react@16.13.1
       react-router-config: registry.npmjs.org/react-router-config/5.1.1_react-router@5.3.1+react@16.13.1
@@ -2173,7 +3332,7 @@ packages:
       react-dom: '*'
     dependencies:
       '@docusaurus/types': registry.npmjs.org/@docusaurus/types/2.0.0-beta.18
-      '@types/react': registry.npmjs.org/@types/react/18.0.8
+      '@types/react': 18.0.8
       '@types/react-router-config': registry.npmjs.org/@types/react-router-config/5.0.6
       '@types/react-router-dom': registry.npmjs.org/@types/react-router-dom/5.3.3
       react: registry.npmjs.org/react/16.13.1
@@ -2904,7 +4063,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       callsites: registry.npmjs.org/callsites/3.1.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       source-map: registry.npmjs.org/source-map/0.6.1
     dev: true
 
@@ -2927,7 +4086,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/test-result': registry.npmjs.org/@jest/test-result/27.5.1
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-haste-map: registry.npmjs.org/jest-haste-map/27.5.1
       jest-runtime: registry.npmjs.org/jest-runtime/27.5.1
     transitivePeerDependencies:
@@ -4737,7 +5896,7 @@ packages:
     version: 5.0.6
     dependencies:
       '@types/history': registry.npmjs.org/@types/history/4.7.11
-      '@types/react': registry.npmjs.org/@types/react/18.0.8
+      '@types/react': 18.0.8
       '@types/react-router': registry.npmjs.org/@types/react-router/5.1.18
     dev: false
 
@@ -4747,7 +5906,7 @@ packages:
     version: 5.3.3
     dependencies:
       '@types/history': registry.npmjs.org/@types/history/4.7.11
-      '@types/react': registry.npmjs.org/@types/react/18.0.8
+      '@types/react': 18.0.8
       '@types/react-router': registry.npmjs.org/@types/react-router/5.1.18
     dev: false
 
@@ -4757,7 +5916,7 @@ packages:
     version: 5.1.18
     dependencies:
       '@types/history': registry.npmjs.org/@types/history/4.7.11
-      '@types/react': registry.npmjs.org/@types/react/18.0.8
+      '@types/react': 18.0.8
     dev: false
 
   registry.npmjs.org/@types/react/18.0.8:
@@ -5540,7 +6699,7 @@ packages:
       babel-plugin-istanbul: registry.npmjs.org/babel-plugin-istanbul/6.1.1
       babel-preset-jest: registry.npmjs.org/babel-preset-jest/27.5.1_@babel+core@7.17.10
       chalk: registry.npmjs.org/chalk/4.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       slash: registry.npmjs.org/slash/3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6170,7 +7329,7 @@ packages:
       normalize-path: registry.npmjs.org/normalize-path/3.0.0
       readdirp: registry.npmjs.org/readdirp/3.6.0
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/2.3.2
+      fsevents: 2.3.2
     dev: false
 
   registry.npmjs.org/chownr/1.1.4:
@@ -6264,7 +7423,7 @@ packages:
     dependencies:
       string-width: registry.npmjs.org/string-width/4.2.3
     optionalDependencies:
-      '@colors/colors': registry.npmjs.org/@colors/colors/1.5.0
+      '@colors/colors': 1.5.0
     dev: false
 
   registry.npmjs.org/cli-truncate/2.1.0:
@@ -7618,16 +8777,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  registry.npmjs.org/encoding/0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz}
-    name: encoding
-    version: 0.1.13
-    requiresBuild: true
-    dependencies:
-      iconv-lite: registry.npmjs.org/iconv-lite/0.6.3
-    dev: true
-    optional: true
-
   registry.npmjs.org/end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz}
     name: end-of-stream
@@ -7816,7 +8965,7 @@ packages:
       esutils: registry.npmjs.org/esutils/2.0.3
       optionator: registry.npmjs.org/optionator/0.8.3
     optionalDependencies:
-      source-map: registry.npmjs.org/source-map/0.6.1
+      source-map: 0.6.1
     dev: true
 
   registry.npmjs.org/eslint-scope/5.1.1:
@@ -8106,8 +9255,8 @@ packages:
     dependencies:
       cross-fetch: registry.npmjs.org/cross-fetch/3.1.5
       fbjs-css-vars: registry.npmjs.org/fbjs-css-vars/1.0.2
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
       promise: registry.npmjs.org/promise/7.3.1
       setimmediate: registry.npmjs.org/setimmediate/1.0.5
       ua-parser-js: registry.npmjs.org/ua-parser-js/0.7.31
@@ -8438,15 +9587,6 @@ packages:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz}
     name: fs.realpath
     version: 1.0.0
-
-  registry.npmjs.org/fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
-    name: fsevents
-    version: 2.3.2
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    optional: true
 
   registry.npmjs.org/function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz}
@@ -8822,7 +9962,7 @@ packages:
       source-map: registry.npmjs.org/source-map/0.6.1
       wordwrap: registry.npmjs.org/wordwrap/1.0.0
     optionalDependencies:
-      uglify-js: registry.npmjs.org/uglify-js/3.15.4
+      uglify-js: 3.15.4
     dev: true
 
   registry.npmjs.org/har-schema/2.0.0:
@@ -9020,7 +10160,7 @@ packages:
     version: 4.10.1
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.17.9
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
+      loose-envify: 1.4.0
       resolve-pathname: registry.npmjs.org/resolve-pathname/3.0.0
       tiny-invariant: registry.npmjs.org/tiny-invariant/1.1.0
       tiny-warning: registry.npmjs.org/tiny-warning/1.0.3
@@ -9032,7 +10172,7 @@ packages:
     name: hoist-non-react-statics
     version: 3.3.2
     dependencies:
-      react-is: registry.npmjs.org/react-is/16.13.1
+      react-is: 16.13.1
     dev: false
 
   registry.npmjs.org/hosted-git-info/2.8.9:
@@ -9524,7 +10664,7 @@ packages:
     name: invariant
     version: 2.2.4
     dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
+      loose-envify: 1.4.0
     dev: false
 
   registry.npmjs.org/ip/1.1.5:
@@ -9737,12 +10877,6 @@ packages:
     dependencies:
       has-tostringtag: registry.npmjs.org/has-tostringtag/1.0.0
     dev: true
-
-  registry.npmjs.org/is-number/7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz}
-    name: is-number
-    version: 7.0.0
-    engines: {node: '>=0.12.0'}
 
   registry.npmjs.org/is-obj/1.0.1:
     resolution: {integrity: sha1-PkcprB9f3gJc19g6iW2rn09n2w8=, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz}
@@ -10246,7 +11380,7 @@ packages:
       micromatch: registry.npmjs.org/micromatch/4.0.5
       walker: registry.npmjs.org/walker/1.0.7
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/2.3.2
+      fsevents: 2.3.2
     dev: true
 
   registry.npmjs.org/jest-jasmine2/27.5.1:
@@ -10451,7 +11585,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/17.0.30
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
     dev: true
 
   registry.npmjs.org/jest-snapshot/27.5.1:
@@ -10714,7 +11848,7 @@ packages:
     name: jsonfile
     version: 4.0.0
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
     dev: true
 
   registry.npmjs.org/jsonfile/6.1.0:
@@ -10724,7 +11858,7 @@ packages:
     dependencies:
       universalify: registry.npmjs.org/universalify/2.0.0
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
 
   registry.npmjs.org/jsonparse/1.3.1:
     resolution: {integrity: sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz}
@@ -11575,7 +12709,7 @@ packages:
       minipass-sized: registry.npmjs.org/minipass-sized/1.0.3
       minizlib: registry.npmjs.org/minizlib/2.1.2
     optionalDependencies:
-      encoding: registry.npmjs.org/encoding/0.1.13
+      encoding: 0.1.13
     dev: true
 
   registry.npmjs.org/minipass-flush/1.0.5:
@@ -11819,7 +12953,7 @@ packages:
     dependencies:
       env-paths: registry.npmjs.org/env-paths/2.2.1
       glob: registry.npmjs.org/glob/7.2.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       mkdirp: registry.npmjs.org/mkdirp/0.5.5
       nopt: registry.npmjs.org/nopt/4.0.3
       npmlog: registry.npmjs.org/npmlog/4.1.2
@@ -11839,7 +12973,7 @@ packages:
     dependencies:
       env-paths: registry.npmjs.org/env-paths/2.2.1
       glob: registry.npmjs.org/glob/7.2.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       nopt: registry.npmjs.org/nopt/5.0.0
       npmlog: registry.npmjs.org/npmlog/4.1.2
       request: registry.npmjs.org/request/2.88.2
@@ -13790,7 +14924,7 @@ packages:
       webpack: '>=4.41.1 || 5.x'
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.17.9
-      react-loadable: registry.npmjs.org/@docusaurus/react-loadable/5.5.2_react@16.13.1
+      react-loadable: /@docusaurus/react-loadable/5.5.2_react@16.13.1
       webpack: registry.npmjs.org/webpack/5.72.0
     dev: false
 
@@ -15759,7 +16893,7 @@ packages:
     version: 5.0.1
     engines: {node: '>=8.0'}
     dependencies:
-      is-number: registry.npmjs.org/is-number/7.0.0
+      is-number: 7.0.0
 
   registry.npmjs.org/toidentifier/1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz}
@@ -16094,16 +17228,6 @@ packages:
     name: ua-parser-js
     version: 0.7.31
     dev: false
-
-  registry.npmjs.org/uglify-js/3.15.4:
-    resolution: {integrity: sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz}
-    name: uglify-js
-    version: 3.15.4
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    requiresBuild: true
-    dev: true
-    optional: true
 
   registry.npmjs.org/uid-number/0.0.6:
     resolution: {integrity: sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz}
@@ -17009,7 +18133,7 @@ packages:
     name: write-file-atomic
     version: 2.4.3
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       imurmurhash: registry.npmjs.org/imurmurhash/0.1.4
       signal-exit: registry.npmjs.org/signal-exit/3.0.7
     dev: true
@@ -17031,7 +18155,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       detect-indent: registry.npmjs.org/detect-indent/5.0.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       make-dir: registry.npmjs.org/make-dir/2.1.0
       pify: registry.npmjs.org/pify/4.0.1
       sort-keys: registry.npmjs.org/sort-keys/2.0.0


### PR DESCRIPTION
PNPM uses `pnpm-workspace.yaml` to manage its workspaces, so the workspaces field in `package.json` is not actually required. However, monorepolint assumes that `workspaces` is defined in the root package.json to work, which means that pnpm repos have an unnecessary duplication of workspaces defined in both package.json and pnpm-workspace.yaml

This PR changes it so that monorepolint can deal with either scenario. For pnpm-workspace.yaml, I just used pnpm's own utilities to find the workspace directories + workspace root. If that returns null, it falls back to the current logic. This resulted in several functions becoming async, but I'm hoping that's ok.