### PR TITLE
Fix PNPM package dirs logic

### DIFF
--- a/packages/utils/src/getWorkspacePackageDirs.ts
+++ b/packages/utils/src/getWorkspacePackageDirs.ts
@@ -27,7 +27,7 @@ export async function getWorkspacePackageDirs(
     if (workspacePackages.length === 0) {
       throw new Error("Invalid workspaceDir: " + workspaceDir);
     }
-    ret.push(...workspacePackages.map((project) => pathJoin(project.dir, "package.json")));
+    ret.push(...workspacePackages.map((project) => project.dir));
     return ret;
   }
 


### PR DESCRIPTION
The getWorkspacePackageDirs() needs to return directories, not paths to package.json