### PR TITLE
Dynamic import find-up

### DIFF
--- a/packages/utils/src/findWorkspaceDir.ts
+++ b/packages/utils/src/findWorkspaceDir.ts
@@ -5,17 +5,16 @@
  *
  */
 
+import { dirname, join, normalize } from "path";
+import { promises } from "fs";
 import { Host } from "./Host.js";
 import { PackageJson } from "./PackageJson.js";
 
 export async function findPnpmWorkspaceDir(dir: string) {
-  const dirname = import("path").then((path) => path.dirname);
-  const workspaceManifestLocation = await import("fs").then((fs) =>
-    import("find-up").then((find) =>
-      fs.promises.realpath(dir).then((cwd) => find.findUp("pnpm-workspace.yaml", { cwd }))
-    )
+  const workspaceManifestLocation = await import("find-up").then((find) =>
+    promises.realpath(dir).then((cwd) => find.findUp("pnpm-workspace.yaml", { cwd }))
   );
-  return workspaceManifestLocation && (await dirname)(workspaceManifestLocation);
+  return workspaceManifestLocation && dirname(workspaceManifestLocation);
 }
 
 export async function findWorkspaceDir(
@@ -23,14 +22,13 @@ export async function findWorkspaceDir(
   dir: string
 ): Promise<string | undefined> {
   // Defining workspaces in package.json is not necessary in PNPM
-  const path = await import("path");
   const maybePnpmWorkspaceDir = await findPnpmWorkspaceDir(dir);
   if (maybePnpmWorkspaceDir != null) {
     return maybePnpmWorkspaceDir;
   }
 
   // We may not be in a repository that uses PNPM, look for workspaces in package.json
-  const packagePath = path.join(dir, "package.json");
+  const packagePath = join(dir, "package.json");
   if (host.exists(packagePath)) {
     const packageJson = host.readJson(packagePath) as PackageJson;
     if (packageJson.workspaces !== undefined) {
@@ -38,7 +36,7 @@ export async function findWorkspaceDir(
     }
   }
 
-  const nextDir = path.normalize(path.join(dir, ".."));
+  const nextDir = normalize(join(dir, ".."));
   if (nextDir === dir) {
     return undefined;
   }

--- a/packages/utils/src/findWorkspaceDir.ts
+++ b/packages/utils/src/findWorkspaceDir.ts
@@ -9,9 +9,9 @@ import * as path from "path";
 import { Host } from "./Host.js";
 import { PackageJson } from "./PackageJson.js";
 import * as fs from "fs";
-import { findUp } from "find-up";
 
 export async function findPnpmWorkspaceDir(cwd: string) {
+  const { findUp } = await import("find-up");
   const workspaceManifestLocation = await findUp("pnpm-workspace.yaml", {
     cwd: await fs.promises.realpath(cwd),
   });

--- a/packages/utils/src/findWorkspaceDir.ts
+++ b/packages/utils/src/findWorkspaceDir.ts
@@ -5,16 +5,17 @@
  *
  */
 
-import { dirname, join, normalize } from "path";
-import { promises } from "fs";
+import * as fs from "fs";
+import * as path from "path";
 import { Host } from "./Host.js";
 import { PackageJson } from "./PackageJson.js";
 
-export async function findPnpmWorkspaceDir(dir: string) {
-  const workspaceManifestLocation = await import("find-up").then((find) =>
-    promises.realpath(dir).then((cwd) => find.findUp("pnpm-workspace.yaml", { cwd }))
-  );
-  return workspaceManifestLocation && dirname(workspaceManifestLocation);
+export async function findPnpmWorkspaceDir(cwd: string) {
+  const { findUp } = await import("find-up");
+  const workspaceManifestLocation = await findUp("pnpm-workspace.yaml", {
+    cwd: await fs.promises.realpath(cwd),
+  });
+  return workspaceManifestLocation && path.dirname(workspaceManifestLocation);
 }
 
 export async function findWorkspaceDir(
@@ -28,7 +29,7 @@ export async function findWorkspaceDir(
   }
 
   // We may not be in a repository that uses PNPM, look for workspaces in package.json
-  const packagePath = join(dir, "package.json");
+  const packagePath = path.join(dir, "package.json");
   if (host.exists(packagePath)) {
     const packageJson = host.readJson(packagePath) as PackageJson;
     if (packageJson.workspaces !== undefined) {
@@ -36,7 +37,7 @@ export async function findWorkspaceDir(
     }
   }
 
-  const nextDir = normalize(join(dir, ".."));
+  const nextDir = path.normalize(path.join(dir, ".."));
   if (nextDir === dir) {
     return undefined;
   }

--- a/packages/utils/src/findWorkspaceDir.ts
+++ b/packages/utils/src/findWorkspaceDir.ts
@@ -5,17 +5,17 @@
  *
  */
 
-import * as path from "path";
+import { dirname, join, normalize } from "path";
 import { Host } from "./Host.js";
 import { PackageJson } from "./PackageJson.js";
-import * as fs from "fs";
 
 export async function findPnpmWorkspaceDir(cwd: string) {
   const { findUp } = await import("find-up");
+  const { promises } = await import("fs");
   const workspaceManifestLocation = await findUp("pnpm-workspace.yaml", {
-    cwd: await fs.promises.realpath(cwd),
+    cwd: await promises.realpath(cwd),
   });
-  return workspaceManifestLocation && path.dirname(workspaceManifestLocation);
+  return workspaceManifestLocation && dirname(workspaceManifestLocation);
 }
 
 export async function findWorkspaceDir(
@@ -29,7 +29,7 @@ export async function findWorkspaceDir(
   }
 
   // We may not be in a repository that uses PNPM, look for workspaces in package.json
-  const packagePath = path.join(dir, "package.json");
+  const packagePath = join(dir, "package.json");
   if (host.exists(packagePath)) {
     const packageJson = host.readJson(packagePath) as PackageJson;
     if (packageJson.workspaces !== undefined) {
@@ -37,7 +37,7 @@ export async function findWorkspaceDir(
     }
   }
 
-  const nextDir = path.normalize(path.join(dir, ".."));
+  const nextDir = normalize(join(dir, ".."));
   if (nextDir === dir) {
     return undefined;
   }

--- a/packages/utils/src/findWorkspaceDir.ts
+++ b/packages/utils/src/findWorkspaceDir.ts
@@ -5,17 +5,17 @@
  *
  */
 
-import { dirname, join, normalize } from "path";
 import { Host } from "./Host.js";
 import { PackageJson } from "./PackageJson.js";
 
-export async function findPnpmWorkspaceDir(cwd: string) {
-  const { findUp } = await import("find-up");
-  const { promises } = await import("fs");
-  const workspaceManifestLocation = await findUp("pnpm-workspace.yaml", {
-    cwd: await promises.realpath(cwd),
-  });
-  return workspaceManifestLocation && dirname(workspaceManifestLocation);
+export async function findPnpmWorkspaceDir(dir: string) {
+  const dirname = import("path").then((path) => path.dirname);
+  const workspaceManifestLocation = await import("fs").then((fs) =>
+    import("find-up").then((find) =>
+      fs.promises.realpath(dir).then((cwd) => find.findUp("pnpm-workspace.yaml", { cwd }))
+    )
+  );
+  return workspaceManifestLocation && (await dirname)(workspaceManifestLocation);
 }
 
 export async function findWorkspaceDir(
@@ -23,13 +23,14 @@ export async function findWorkspaceDir(
   dir: string
 ): Promise<string | undefined> {
   // Defining workspaces in package.json is not necessary in PNPM
+  const path = await import("path");
   const maybePnpmWorkspaceDir = await findPnpmWorkspaceDir(dir);
   if (maybePnpmWorkspaceDir != null) {
     return maybePnpmWorkspaceDir;
   }
 
   // We may not be in a repository that uses PNPM, look for workspaces in package.json
-  const packagePath = join(dir, "package.json");
+  const packagePath = path.join(dir, "package.json");
   if (host.exists(packagePath)) {
     const packageJson = host.readJson(packagePath) as PackageJson;
     if (packageJson.workspaces !== undefined) {
@@ -37,7 +38,7 @@ export async function findWorkspaceDir(
     }
   }
 
-  const nextDir = normalize(join(dir, ".."));
+  const nextDir = path.normalize(path.join(dir, ".."));
   if (nextDir === dir) {
     return undefined;
   }

--- a/packages/utils/src/getPackageNameToDir.ts
+++ b/packages/utils/src/getPackageNameToDir.ts
@@ -5,7 +5,7 @@
  *
  */
 
-import { join as pathJoin } from "path";
+import * as path from "path";
 import { getWorkspacePackageDirs } from "./getWorkspacePackageDirs.js";
 import { Host } from "./Host.js";
 import { PackageJson } from "./PackageJson.js";
@@ -23,7 +23,7 @@ export async function getPackageNameToDir(
 
   const workspacePackages = await getWorkspacePackageDirs(host, workspaceDir, resolvePaths);
   for (const packageDir of workspacePackages) {
-    const packagePath = pathJoin(packageDir, "package.json");
+    const packagePath = path.join(packageDir, "package.json");
     const { name } = host.readJson(packagePath) as PackageJson;
     if (name === undefined) {
       throw new Error(`Package needs a name: ${packagePath}`);

--- a/packages/utils/src/getWorkspacePackageDirs.ts
+++ b/packages/utils/src/getWorkspacePackageDirs.ts
@@ -5,21 +5,20 @@
  *
  */
 
-import { existsSync } from "fs";
+import * as fs from "fs";
 import * as glob from "glob";
-import * as path from "node:path";
-import * as fs from "node:fs";
+import * as path from "path";
 import { Host } from "./Host.js";
 import { PackageJson } from "./PackageJson.js";
-import * as readYamlFile from "read-yaml-file";
-import { findPackages } from "find-packages";
 
 async function findPNPMWorkspacePackages(workspaceRoot: string) {
   workspaceRoot = fs.realpathSync(workspaceRoot);
-  const workspaceManifest = await readYamlFile.default<{ packages?: string[] }>(
+  const { default: readYamlFile } = await import("read-yaml-file");
+  const workspaceManifest = await readYamlFile<{ packages?: string[] }>(
     path.join(workspaceRoot, "pnpm-workspace.yaml")
   );
 
+  const { findPackages } = await import("find-packages");
   return findPackages(workspaceRoot, {
     ignore: ["**/node_modules/**", "**/bower_components/**"],
     includeRoot: true,
@@ -56,7 +55,7 @@ export async function getWorkspacePackageDirs(
     for (const packagePath of glob.sync(pattern, { cwd: workspaceDir })) {
       const packageJsonPath = path.join(workspaceDir, packagePath, "package.json");
 
-      if (existsSync(packageJsonPath)) {
+      if (fs.existsSync(packageJsonPath)) {
         if (resolvePaths === true) {
           ret.push(path.resolve(path.join(workspaceDir, packagePath)));
         } else {


### PR DESCRIPTION
Fix invalid `require("find-up")` in CJS:

```
> Task :app:monorepolint FAILED
/home/user/project/node_modules/.pnpm/@monorepolint+utils@0.5.0-alpha.103/node_modules/@monorepolint/utils/build/js/index.cjs:123
var import_find_up = require("find-up");
                     ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/user/project/node_modules/.pnpm/find-up@6.3.0/node_modules/find-up/index.js from /home/user/project/node_modules/.pnpm/@monorepolint+utils@0.5.0-alpha.103/node_modules/@monorepolint/utils/build/js/index.cjs not supported.
Instead change the require of index.js in /home/user/project/node_modules/.pnpm/@monorepolint+utils@0.5.0-alpha.103/node_modules/@monorepolint/utils/build/js/index.cjs to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/home/user/project/node_modules/.pnpm/@monorepolint+utils@0.5.0-alpha.103/node_modules/@monorepolint/utils/build/js/index.cjs:123:22)
    at Object.<anonymous> (/home/user/project/node_modules/.pnpm/@monorepolint+core@0.5.0-alpha.103/node_modules/@monorepolint/core/build/js/index.cjs:37:21)
    at Object.<anonymous> (/home/user/project/node_modules/.pnpm/@monorepolint+cli@0.5.0-alpha.96/node_modules/@monorepolint/cli/lib/index.js:10:16)
    at Object.<anonymous> (/home/user/project/node_modules/.pnpm/@monorepolint+cli@0.5.0-alpha.96/node_modules/@monorepolint/cli/bin/mrl:3:1)
  code: 'ERR_REQUIRE_ESM'
}
```
