### PR TITLE
Fix @monorepolint/rules import in docs

### DIFF
--- a/.changeset/late-zoos-watch.md
+++ b/.changeset/late-zoos-watch.md
@@ -1,0 +1,5 @@
+---
+"@monorepolint/docs": patch
+---
+
+Fix @monorepolint/rules import in docs

--- a/packages/docs/docs/rules/alphabetical-scripts.md
+++ b/packages/docs/docs/rules/alphabetical-scripts.md
@@ -7,7 +7,7 @@ Ensures that all scripts within a project are ordered alphabetically.
 ### Usage
 
 ```javascript
-import { alphabeticalScripts } from "monorepolint/rules";
+import { alphabeticalScripts } from "@monorepolint/rules";
 
 export default {
   rules: [

--- a/packages/docs/docs/rules/banned-dependencies.md
+++ b/packages/docs/docs/rules/banned-dependencies.md
@@ -24,7 +24,7 @@ documented.
 ### Example
 
 ```javascript
-import { bannedDependencies } from "monorepolint/rules";
+import { bannedDependencies } from "@monorepolint/rules";
 
 export default {
   rules: [

--- a/packages/docs/docs/rules/consistent-dependencies.md
+++ b/packages/docs/docs/rules/consistent-dependencies.md
@@ -9,7 +9,7 @@ If your root package.json has a dependency on `"somelib": "^1.0.0"` then all chi
 ### Example
 
 ```javascript
-import { consistentDependencies } from "monorepolint/rules";
+import { consistentDependencies } from "@monorepolint/rules";
 export default {
   rules: [
     consistentDependencies({}),

--- a/packages/docs/docs/rules/file-contents.md
+++ b/packages/docs/docs/rules/file-contents.md
@@ -20,7 +20,7 @@ Exactly one of `generator`, `template`, or `templateFile` needs to be specified.
 ### Example
 
 ```js
-import { fileContents } from "monorepolint/rules";
+import { fileContents } from "@monorepolint/rules";
 export default {
   rules: [
     fileContents({

--- a/packages/docs/docs/rules/must-satisfy-peer-dependencies.md
+++ b/packages/docs/docs/rules/must-satisfy-peer-dependencies.md
@@ -14,7 +14,7 @@ Ensures that packages satisfy peer dependency requirements declared by their dep
 ### Example
 
 ```javascript
-import { mustSatisfyPeerDependencies } from "monorepolint/rules";
+import { mustSatisfyPeerDependencies } from "@monorepolint/rules";
 export default {
   rules: [
     mustSatisfyPeerDependencies({

--- a/packages/docs/docs/rules/nested-workspaces.md
+++ b/packages/docs/docs/rules/nested-workspaces.md
@@ -8,7 +8,7 @@ In particular, this ensures that nested workspaces (e.g. `packages/group/*`) are
 ### Example
 
 ```javascript
-import { nestedWorkspaces } from "monorepolint/rules";
+import { nestedWorkspaces } from "@monorepolint/rules";
 export default {
   rules: [nestedWorkspaces({})],
 };

--- a/packages/docs/docs/rules/package-entry.md
+++ b/packages/docs/docs/rules/package-entry.md
@@ -16,7 +16,7 @@ Standardize arbitrary entries in package.json.
 ### Example
 
 ```javascript
-import { packageEntry } from "monorepolint/rules";
+import { packageEntry } from "@monorepolint/rules";
 export default {
   rules: [
     packageEntry({

--- a/packages/docs/docs/rules/package-order.md
+++ b/packages/docs/docs/rules/package-order.md
@@ -12,7 +12,7 @@ Standardize entry order in package.json.
 ### Example
 
 ```javascript
-import { packageOrder } from "monorepolint/rules";
+import { packageOrder } from "@monorepolint/rules";
 export default {
   rules: [
     packageOrder({

--- a/packages/docs/docs/rules/package-script.md
+++ b/packages/docs/docs/rules/package-script.md
@@ -16,7 +16,7 @@ Standardize package scripts. This is a separate rule from Package Entries to mak
 ### Example
 
 ```javascript
-import { packageScript } from "monorepolint/rules";
+import { packageScript } from "@monorepolint/rules";
 export default {
   rules: [
     packageScript({

--- a/packages/docs/docs/rules/require-dependency.md
+++ b/packages/docs/docs/rules/require-dependency.md
@@ -21,7 +21,7 @@ local entry.
 ### Example
 
 ```javascript
-import { requireDependency } from "monorepolint/rules";
+import { requireDependency } from "@monorepolint/rules";
 export default {
   rules: [
     requireDependency({

--- a/packages/docs/docs/rules/standard-tsconfig.md
+++ b/packages/docs/docs/rules/standard-tsconfig.md
@@ -26,7 +26,7 @@ Exactly one of `generator`, `template`, or `templateFile` needs to be specified.
 ### Example
 
 ```javascript
-import { standardTsconfig } from "monorepolint/rules";
+import { standardTsconfig } from "@monorepolint/rules";
 export default {
   rules: [
     standardTsconfig({


### PR DESCRIPTION
I noticed the imports weren't consistent across the rules docs 🙂 