### PR TITLE
fix: Update CodeQL workflow to use v3 actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Updates CodeQL action from deprecated v2 to current v3
- Fixes deprecation warnings in CodeQL workflow runs
- Ensures continued security scanning support

## Background
CodeQL Action v2 was officially deprecated in January 2025. The workflow was showing deprecation warnings and may eventually break without this update.

## Test plan
- [x] Updated workflow file with v3 action versions
- [ ] Verify CodeQL runs successfully without deprecation warnings
- [ ] Confirm security scanning continues to work properly