### PR TITLE
docs: add archetype rule integration example

### DIFF
--- a/packages/docs/docs/guides/archetypes.md
+++ b/packages/docs/docs/guides/archetypes.md
@@ -86,6 +86,66 @@ export default archetypes<MyRules>(
   );
 ```
 
+### Using archetype options in rule configuration
+
+The first argument passed to your `rulesProvider` contains the package selector
+for the current archetype. Spread it into each rule so the generated rule only
+applies to packages in that archetype. The second argument is the options object
+you passed to `.addArchetype(...)`, which lets each archetype parameterize the
+same rule template.
+
+For example, this complete configuration uses each archetype's `lint` and
+`build` commands to configure the `packageScript` rule:
+
+```ts
+import { archetypes } from "@monorepolint/archetypes";
+import { packageScript } from "@monorepolint/rules";
+
+interface ScriptRules {
+  build: string;
+  lint: string;
+}
+
+const config = archetypes<ScriptRules>(
+  (shared, rules) => [
+    packageScript({
+      ...shared,
+      options: {
+        scripts: {
+          build: {
+            options: [rules.build],
+            fixValue: rules.build,
+          },
+          lint: {
+            options: [rules.lint],
+            fixValue: rules.lint,
+          },
+        },
+      },
+    }),
+  ],
+  { unmatched: "error" },
+)
+  .addArchetype("vite libraries", ["@mine/vite-*"], {
+    build: "vite build",
+    lint: "eslint .",
+  })
+  .addArchetype("tsc libraries", ["@mine/tsc-*"], {
+    build: "tsc",
+    lint: "eslint .",
+  });
+
+export default {
+  rules: config.buildRules(),
+};
+```
+
+This produces a `packageScript` rule for each archetype. The `shared` spread
+sets `includePackages` for the packages registered with that archetype, and
+`rules.build` / `rules.lint` provide the allowed script values and autofix
+values for those packages. The final `config.buildRules()` call emits the
+`rules` array consumed by monorepolint.
+
 ### Using fallback configuration
 
 If in our earlier example we want all unmatched packages to use a default configuration instead of erroring we can do that as well:


### PR DESCRIPTION
## Summary

Adds a concrete `packageScript` example to the archetypes guide.

The new section shows how to:

- spread `shared` into a real rule so the generated rule is scoped to the current archetype's packages;
- read archetype-specific values from the `rules` argument;
- use those values to parameterize `packageScript` options and autofix values.
- export a complete monorepolint config with `rules: config.buildRules()`.

Closes #462.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec dprint fmt packages/docs/docs/guides/archetypes.md`
- `pnpm exec dprint check packages/docs/docs/guides/archetypes.md`
- `pnpm exec tsc -b packages/config/tsconfig.json packages/rules/tsconfig.json packages/archetypes/tsconfig.json`
- `git diff --check`

I also tried `pnpm --filter @monorepolint/docs build-docs`, but it fails before rendering docs because the current dependency tree has mismatched Docusaurus package versions:

```text
Invalid name=docusaurus-plugin-content-docs version number=3.8.1.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.9.2).
```
