### PR TITLE
Require Node >=20 across all packages

### DIFF
--- a/.changeset/brave-hoops-attend.md
+++ b/.changeset/brave-hoops-attend.md
@@ -1,0 +1,10 @@
+---
+"@monorepolint/archetypes": minor
+"@monorepolint/config": minor
+"@monorepolint/core": minor
+"@monorepolint/rules": minor
+"@monorepolint/utils": minor
+"monorepolint": minor
+---
+
+Raise the declared Node requirement from `>=18` to `>=20`. The published packages' runtime dependencies already required Node 20 — `find-up@8` and `glob` in `utils` and `archetypes`, `globby@16` in `rules`, and `yargs@18` in the CLI — so the previous `>=18` overstated what actually worked.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "compile:fast": "cd packages/all; tsc --build",
     "compile:watch": "cd packages/all; tsc --build --watch",
     "fix:lint:format": "dprint fmt 'packages/*/src/**/*.{ts,tsx,less}'",
-    "fix:lint:monorepolint": "pnpm exec monorepolint fix",
+    "fix:lint:monorepolint": "pnpm exec monorepolint check --fix",
     "lint": "pnpm run --workspace-concurrency 1 '/^lint:.*/'",
     "lint:format": "dprint check 'packages/*/src/**/*.{ts,tsx,less}'",
     "lint:monorepolint": "monorepolint check --verbose",

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -13,7 +13,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {},
   "dependencies": {

--- a/packages/archetypes/package.json
+++ b/packages/archetypes/package.json
@@ -16,7 +16,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rm -rf build dist lib node_modules *.tgz tsconfig.tsbuildinfo",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "bin": {
     "monorepolint": "./bin/monorepolint.mjs",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,7 +19,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rm -rf build dist lib node_modules *.tgz tsconfig.tsbuildinfo",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rm -rf build dist lib node_modules *.tgz tsconfig.tsbuildinfo",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build-docs": "docusaurus build",

--- a/packages/internal-mrl-config/package.json
+++ b/packages/internal-mrl-config/package.json
@@ -15,7 +15,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rm -rf build dist lib node_modules *.tgz tsconfig.tsbuildinfo",

--- a/packages/internal-mrl-config/src/monorepolint.config.ts
+++ b/packages/internal-mrl-config/src/monorepolint.config.ts
@@ -120,7 +120,7 @@ export default defineProject({
               },
             },
             engines: {
-              node: ">=18",
+              node: ">=20",
             },
           },
         },

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -19,7 +19,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rm -rf build dist lib node_modules *.tgz tsconfig.tsbuildinfo",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rm -rf build dist lib node_modules *.tgz tsconfig.tsbuildinfo",


### PR DESCRIPTION
Sets the minimum Node version to `>=20` everywhere, for v0.6.0.

## How

The source of truth is the `Rules.packageEntry` entry in `packages/internal-mrl-config/src/monorepolint.config.ts` — monorepolint enforces `engines` on itself. Changed it there and propagated to the nine `package.json` files with `monorepolint check --fix`. The workspace root was already `>=20`.

## This corrects metadata that was already wrong

Worth being clear that this isn't dropping support that worked — every published package's **runtime** dependencies already required Node 20 or newer:

| Package | Dep forcing the floor | Its `engines.node` |
|---|---|---|
| `utils`, `archetypes` | `find-up@8` | `>=20` |
| `utils`, `archetypes` | `glob@13` | `18 \|\| 20 \|\| >=22` (glob@11 was `20 \|\| >=22`) |
| `rules` | `globby@16` | `>=20` |
| `cli` | `yargs@18` | `^20.19.0 \|\| ^22.12.0 \|\| >=23` |
| `config`, `core` | no direct floor; both depend on `utils` | — |

So a consumer on Node 18 installing `@monorepolint/cli` already received a package whose own dependencies declared they needed 20 or newer. The `>=18` was aspirational.

Note this is unrelated to the ESLint 10 upgrade in #487 — `eslint` is a devDependency in all six published packages, so it never constrained consumers.

## Two known imprecisions in `>=20`

Deliberate simplifications:

- `yargs` actually wants **20.19.0**, not 20.0.0
- `yargs` excludes **Node 21** entirely (`^20.19.0 || ^22.12.0 || >=23`)

A plain `>=20` reads better than the exact union, and both gaps are theoretical — Node 21 is EOL, and 20.x below 20.19.0 is old enough to be unlikely in practice. Flagging so the choice is visible rather than accidental.

## Verification

`turbo check --force` — 29/29 tasks, rebased on top of the eslint 10 (#487) and glob/globby (#486) merges.

## Also: fix the `fix:lint:monorepolint` script

The root script ran `monorepolint fix`. There is no `fix` subcommand, so it failed with `Unknown command: fix`. Changed to `monorepolint check --fix`.

It has been broken since **2018**. The CLI shipped *both* a standalone `fix` command and a `check --fix` flag in the original scaffolding commit (`557030c`, 2018-12-18). Two days later, `dc5be7e` ("Enables type inference from yargs") refactored the yargs setup from the object form to the positional form and dropped the standalone `fix` command in the process — apparently as collateral, since the commit's purpose was type inference. It was never re-added, and there's no deprecation note or changelog entry.

Why it sat unnoticed: nothing in CI calls it. `lint` only runs `/^lint:.*/`, and `ci` goes through `lint:monorepolint` — the read-only `check --verbose` path. The fix script is manual-only, so it only fails when a human reaches for it.

The CLI's own error output has been pointing at the correct form the whole time (`packages/cli/src/index.ts:96` prints *"To automatically fix errors, run `<cmd> check --fix`"*).

Verified by reverting one package's `engines` to `>=18` and confirming the script detects and repairs it — not merely that it exits cleanly.
