### PR TITLE
chore(archetypes): remove unused glob, micromatch, @types/micromatch deps

### DIFF
--- a/.changeset/tame-plums-jump.md
+++ b/.changeset/tame-plums-jump.md
@@ -1,0 +1,5 @@
+---
+"@monorepolint/archetypes": patch
+---
+
+Removed unused `glob`, `micromatch`, and `@types/micromatch` dependencies. None of the package's source files import them; the real consumers of these packages live in `@monorepolint/utils`.

--- a/packages/archetypes/package.json
+++ b/packages/archetypes/package.json
@@ -31,13 +31,10 @@
     "@monorepolint/rules": "workspace:^",
     "find-packages": "^10.0.4",
     "find-up": "^8.0.0",
-    "glob": "^13.0.6",
-    "micromatch": "^4.0.8",
     "read-yaml-file": "^2.1.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@types/micromatch": "^4.0.10",
     "@types/node": "^22.20.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",
     "@typescript-eslint/parser": "^8.69.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,12 +146,6 @@ importers:
       find-up:
         specifier: ^8.0.0
         version: 8.0.0
-      glob:
-        specifier: ^13.0.6
-        version: 13.0.6
-      micromatch:
-        specifier: ^4.0.8
-        version: 4.0.8
       read-yaml-file:
         specifier: ^2.1.0
         version: 2.1.0
@@ -159,9 +153,6 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
     devDependencies:
-      '@types/micromatch':
-        specifier: ^4.0.10
-        version: 4.0.10
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1


### PR DESCRIPTION
## What

Removes three dependencies from `packages/archetypes/package.json` that nothing in the package imports:

- `glob` (runtime `dependencies`)
- `micromatch` (runtime `dependencies`)
- `@types/micromatch` (`devDependencies`)

Closes #488

## Evidence it's unused

`packages/archetypes/src` contains exactly five files: `archetypes.ts`, `ArchetypesImpl.ts`, `ifTrue.ts`, `ifTrue.test.ts`, `index.ts`.

```
$ grep -rn "glob" packages/archetypes/src
no matches
$ grep -rn "micromatch" packages/archetypes/src
no matches
```

The real consumers of `glob` and `micromatch` are in `@monorepolint/utils` (`getWorkspacePackageDirs.ts` uses `glob`, `matchesAnyGlob.ts` uses `micromatch`), whose dependency block is otherwise near-identical to `archetypes`'s — these entries look copy-pasted rather than deliberately chosen. They were bumped in lockstep with `packages/utils` in #486 to avoid version drift; this PR takes the cleaner route of dropping them instead.

## monorepolint self-lint check

This repo lints itself via `check-mrl`. `packages/internal-mrl-config/src/monorepolint.config.ts` runs `Rules.consistentDependencies({})`, which only enforces that a dependency's version matches the workspace root's version *if the package already declares that dependency* — it does not require any specific dependency to be present. So removing these three entries entirely does not trip that rule. Confirmed by running the full check below.

## Verification

- `CI=1 pnpm install --no-frozen-lockfile` — regenerated `pnpm-lock.yaml`
- `CI=1 pnpm install --frozen-lockfile` — passes against the regenerated lockfile
- `CI=1 pnpm turbo check --force` — **29/29 tasks passed**, including `check-mrl`
- `CI=1 pnpm exec changeset status` — validates cleanly with the added changeset

## Changeset

Added `.changeset/tame-plums-jump.md` bumping `@monorepolint/archetypes` at `patch`, since it's a published package and this changes its published `dependencies`/`devDependencies`.