### PR TITLE
Add test coverage for getWorkspacePackageDirs and fix negated pattern bug

### DIFF
--- a/.changeset/tame-plums-teach.md
+++ b/.changeset/tame-plums-teach.md
@@ -1,0 +1,5 @@
+---
+"@monorepolint/utils": patch
+---
+
+Fix `getWorkspacePackageDirs` silently ignoring negated workspace patterns (e.g. `["packages/*", "!packages/excluded"]`) in non-pnpm (yarn/npm `workspaces`) monorepos. Each pattern was previously passed to `glob.sync` in isolation, so a `!`-prefixed pattern was treated as a literal, unmatchable path instead of an exclusion. Positive and negative patterns are now expanded separately and negatives are filtered out of the accumulated result set.

--- a/packages/utils/src/__tests__/getWorkspacePackageDirs.spec.ts
+++ b/packages/utils/src/__tests__/getWorkspacePackageDirs.spec.ts
@@ -1,0 +1,139 @@
+/*!
+ * Copyright 2026 Palantir Technologies, Inc.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ */
+import * as realfs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getWorkspacePackageDirs } from "../getWorkspacePackageDirs.js";
+import { Host } from "../Host.js";
+
+function makeHost(): Pick<Host, "readJson" | "exists"> {
+  return {
+    readJson: (filename: string) => JSON.parse(realfs.readFileSync(filename, "utf-8")),
+    exists: (p: string) => realfs.existsSync(p),
+  };
+}
+
+function writePackage(baseDir: string, relativeDir: string, name: string) {
+  const dir = path.join(baseDir, relativeDir);
+  realfs.mkdirSync(dir, { recursive: true });
+  realfs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name, version: "0.0.0" }),
+    { encoding: "utf-8" },
+  );
+}
+
+function writeRootPackageJson(baseDir: string, workspaces: unknown) {
+  realfs.writeFileSync(
+    path.join(baseDir, "package.json"),
+    JSON.stringify({ name: "root", version: "0.0.0", private: true, workspaces }),
+    { encoding: "utf-8" },
+  );
+}
+
+describe(getWorkspacePackageDirs, () => {
+  let baseDir: string;
+  let host: Pick<Host, "readJson" | "exists">;
+
+  beforeEach(() => {
+    // Resolve symlinks (e.g. macOS's /tmp -> /private/tmp) up front so paths compared
+    // internally by getWorkspacePackageDirs (which realpath's the pnpm workspace root)
+    // agree with the workspaceDir we pass in below.
+    baseDir = realfs.realpathSync(
+      realfs.mkdtempSync(path.join(os.tmpdir(), "mrl-gwpd-test")),
+    );
+    host = makeHost();
+  });
+
+  describe("non-pnpm (yarn/npm workspaces) workspaces", () => {
+    it("expands a plain glob pattern like packages/*", async () => {
+      writeRootPackageJson(baseDir, ["packages/*"]);
+      writePackage(baseDir, "packages/foo", "foo");
+      writePackage(baseDir, "packages/bar", "bar");
+
+      const result = await getWorkspacePackageDirs(host, baseDir);
+
+      expect(result.sort()).toEqual(["packages/bar", "packages/foo"]);
+    });
+
+    it("resolves a literal directory name pattern", async () => {
+      writeRootPackageJson(baseDir, ["apps/main"]);
+      writePackage(baseDir, "apps/main", "main");
+
+      const result = await getWorkspacePackageDirs(host, baseDir);
+
+      expect(result).toEqual(["apps/main"]);
+    });
+
+    it("skips a directory that matches the glob but has no package.json", async () => {
+      writeRootPackageJson(baseDir, ["packages/*"]);
+      writePackage(baseDir, "packages/foo", "foo");
+      realfs.mkdirSync(path.join(baseDir, "packages", "no-package-json"), {
+        recursive: true,
+      });
+
+      const result = await getWorkspacePackageDirs(host, baseDir);
+
+      expect(result).toEqual(["packages/foo"]);
+    });
+
+    it("returns paths relative to workspaceDir by default", async () => {
+      writeRootPackageJson(baseDir, ["packages/*"]);
+      writePackage(baseDir, "packages/foo", "foo");
+
+      const result = await getWorkspacePackageDirs(host, baseDir);
+
+      expect(result).toEqual(["packages/foo"]);
+    });
+
+    it("resolves absolute paths when resolvePaths is true", async () => {
+      writeRootPackageJson(baseDir, ["packages/*"]);
+      writePackage(baseDir, "packages/foo", "foo");
+
+      const result = await getWorkspacePackageDirs(host, baseDir, true);
+
+      expect(result).toEqual([path.resolve(baseDir, "packages/foo")]);
+    });
+
+    it("supports the { packages: [...] } workspaces object form", async () => {
+      writeRootPackageJson(baseDir, { packages: ["packages/*"] });
+      writePackage(baseDir, "packages/foo", "foo");
+
+      const result = await getWorkspacePackageDirs(host, baseDir);
+
+      expect(result).toEqual(["packages/foo"]);
+    });
+
+    it("excludes directories matched by a negated pattern (regression for #489)", async () => {
+      writeRootPackageJson(baseDir, ["packages/*", "!packages/excluded"]);
+      writePackage(baseDir, "packages/foo", "foo");
+      writePackage(baseDir, "packages/excluded", "excluded");
+
+      const result = await getWorkspacePackageDirs(host, baseDir);
+
+      expect(result.sort()).toEqual(["packages/foo"]);
+    });
+  });
+
+  describe("pnpm workspaces", () => {
+    it("expands packages listed in pnpm-workspace.yaml", async () => {
+      writeRootPackageJson(baseDir, undefined);
+      realfs.writeFileSync(
+        path.join(baseDir, "pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\n",
+        { encoding: "utf-8" },
+      );
+      writePackage(baseDir, "packages/foo", "foo");
+      writePackage(baseDir, "packages/bar", "bar");
+
+      const result = await getWorkspacePackageDirs(host, baseDir);
+
+      expect(result.map((p) => path.basename(p)).sort()).toEqual(["bar", "foo"]);
+    });
+  });
+});

--- a/packages/utils/src/getWorkspacePackageDirs.ts
+++ b/packages/utils/src/getWorkspacePackageDirs.ts
@@ -53,13 +53,35 @@ export async function getWorkspacePackageDirs(
     );
   }
 
-  const ret: string[] = [];
   const packageGlobs = Array.isArray(packageJson.workspaces)
     ? packageJson.workspaces
     : packageJson.workspaces.packages || [];
 
-  for (const pattern of packageGlobs) {
+  // Yarn and npm workspaces both support excluding a directory via a "!"-prefixed
+  // pattern (e.g. ["packages/*", "!packages/excluded"]). Negation like this is
+  // inherently cross-pattern, so we expand the positive and negative patterns
+  // separately and then filter the accumulated set, rather than passing each
+  // pattern to glob.sync() in isolation (which would treat "!packages/excluded"
+  // as a literal, unmatchable path).
+  const positivePatterns = packageGlobs.filter((pattern) => !pattern.startsWith("!"));
+  const negativePatterns = packageGlobs
+    .filter((pattern) => pattern.startsWith("!"))
+    .map((pattern) => pattern.slice(1));
+
+  const excludedPackagePaths = new Set<string>();
+  for (const pattern of negativePatterns) {
     for (const packagePath of glob.sync(pattern, { cwd: workspaceDir })) {
+      excludedPackagePaths.add(packagePath);
+    }
+  }
+
+  const ret: string[] = [];
+  for (const pattern of positivePatterns) {
+    for (const packagePath of glob.sync(pattern, { cwd: workspaceDir })) {
+      if (excludedPackagePaths.has(packagePath)) {
+        continue;
+      }
+
       const packageJsonPath = path.join(
         workspaceDir,
         packagePath,


### PR DESCRIPTION
## Summary

`getWorkspacePackageDirs` (packages/utils/src/getWorkspacePackageDirs.ts) had no test coverage — there was no `src/__tests__/getWorkspacePackageDirs.spec.ts`, and the non-pnpm (classic yarn/npm `workspaces`) branch never ran against this repo, since this workspace is itself pnpm-based. That's why `turbo check` passing said nothing about the branch's correctness.

### Tests added

New file: `packages/utils/src/__tests__/getWorkspacePackageDirs.spec.ts`, using `realfs.mkdtempSync` fixtures following the convention in `CachingHost.spec.ts`, with a minimal `Pick<Host, "readJson" | "exists">` built on real fs. Covers:

- Non-pnpm branch: plain glob patterns (`packages/*`), a literal directory name pattern, directories that match the glob but lack a `package.json` (skipped), `resolvePaths: true` vs. the default relative paths, and the `{ packages: [...] }` workspaces object form.
- The pnpm branch (`pnpm-workspace.yaml` + `findPackages`), since it turned out feasible without much extra fixture machinery — the underlying `findPackages`/`readYamlFile` calls read straight from disk regardless of the `host` abstraction.
- A regression test for the bug below.

### Fix

Each workspace glob pattern was being passed to `glob.sync` one at a time:

```js
for (const pattern of packageGlobs) {
  for (const packagePath of glob.sync(pattern, { cwd: workspaceDir })) {
```

Both yarn and npm `workspaces` support negated patterns for exclusion, e.g. `["packages/*", "!packages/excluded"]`. Because `"!packages/excluded"` was glob-matched in isolation, it was treated as a literal (unmatchable) path rather than a negation, so `packages/excluded` still appeared via `packages/*` and the exclusion was silently dropped.

Fixed by splitting `packageGlobs` into positive and negative patterns up front, expanding the negative patterns into an excluded-path set, then filtering positive-pattern matches against that set before the existing `package.json`-existence check. Chose this over adding `globby` (which handles `!pattern` natively and is already used this way in `packages/rules/src/nestedWorkspaces.ts`) to avoid adding a new dependency to `packages/utils` for what's a small, self-contained fix — `glob` was already a dependency here. No lockfile changes were needed.

### Proof the regression test is real

Temporarily reverted just the fix in `getWorkspacePackageDirs.ts` and reran the new spec:

- **Before the fix:** 7/8 tests pass, 1 fails — `excludes directories matched by a negated pattern (regression for #489)` fails with `packages/excluded` incorrectly present in the result.
- **After restoring the fix:** 8/8 tests pass.

### Verification

- `CI=1 pnpm --filter @monorepolint/utils exec vitest run src/__tests__/getWorkspacePackageDirs.spec.ts` → 8/8 passed.
- `CI=1 pnpm turbo check --force` → **29/29 tasks passed**.
- `CI=1 pnpm exec changeset status` → runs cleanly, includes the new changeset (`.changeset/tame-plums-teach.md`, patch bump for `@monorepolint/utils`, since this is a published package and the negation fix is consumer-visible behavior).
- No new dependency was added, so `pnpm-lock.yaml` is untouched and `--frozen-lockfile` still applies.

Closes #489
