### PR TITLE
docs: draft the v0.6.0 release blog post [DO NOT MERGE]

### DIFF
--- a/packages/docs/blog/2026-09-01-060.md
+++ b/packages/docs/blog/2026-09-01-060.md
@@ -1,0 +1,114 @@
+---
+slug: 0.6.0
+title: v0.6.0
+author: Eric Anderson
+author_title: Software Architect @ Palantir
+author_url: https://github.com/ericanderson
+author_image_url: https://avatars0.githubusercontent.com/u/120899?s=400&v=4
+---
+
+v0.6.0 is out, and this time there are real release notes.
+
+When we shipped v0.5.0 I apologized for not having any and promised that changesets would fix that going forward. This post is that promise coming due.
+
+The short version: you can now tell MRL what _shouldn't_ exist, not just what should. Large monorepos get a proper answer for organizing rules. And the minimum supported Node version is now 20.
+
+<!-- truncate -->
+
+## Declarative cleanup with `REMOVE`
+
+Until now MRL was good at making sure things existed and were correct. It was not good at getting rid of things. If you wanted a script gone from every package, or a dependency dropped across the repo, you were on your own.
+
+`REMOVE` fixes that. Import it from `@monorepolint/rules` and use it anywhere you would have put a value:
+
+```ts
+import {
+  fileContents,
+  packageEntry,
+  packageScript,
+  REMOVE,
+  requireDependency,
+} from "@monorepolint/rules";
+
+export default {
+  rules: [
+    // Delete a file if it exists
+    fileContents({
+      file: "unwanted-config.json",
+      template: REMOVE,
+    }),
+
+    // Drop a script, keep managing the others
+    packageScript({
+      scripts: {
+        "outdated-script": REMOVE,
+        build: "tsc",
+      },
+    }),
+
+    // Remove a dependency, from any dependency type
+    requireDependency({
+      dependencies: {
+        lodash: REMOVE,
+        react: "^18.0.0",
+      },
+      devDependencies: {
+        "old-test-lib": REMOVE,
+      },
+    }),
+
+    // Remove a top-level package.json field
+    packageEntry({
+      entries: {
+        browser: REMOVE,
+        main: "./index.js",
+      },
+    }),
+  ],
+};
+```
+
+Four rules understand it — [`fileContents`](/docs/rules/file-contents), [`packageScript`](/docs/rules/package-script), [`requireDependency`](/docs/rules/require-dependency) and [`packageEntry`](/docs/rules/package-entry) — and it means the same thing in all of them. It works with `--fix`, and it is safe to leave in place: removing something that is already gone is not an error, so you can keep the rule around to stop the thing coming back.
+
+## Archetypes for large monorepos
+
+Once a monorepo gets big enough, rule configuration becomes its own maintenance problem. You end up with long chains of `includePackages` and `excludePackages` patterns that are hard to read and easy to get subtly wrong.
+
+[`@monorepolint/archetypes`](/docs/guides/archetypes) is a new package that takes a different approach. Instead of describing which packages to skip, you describe the _kinds_ of packages you have — a published TypeScript library, a test-only package, a sample app — and the rules that belong to each. Every package matches exactly one archetype, and you can make it an error for a package to match none.
+
+## Config as a function
+
+Config files can now be a factory function, and that function can be `async`. This makes it much easier to build configuration up programmatically or to pull in something you need to await first.
+
+The `ConfigFn` type was also fixed to actually reflect that it can be async.
+
+## Two new rules
+
+- [`forceError`](/docs/rules/force-error) — deliberately fail for a set of packages, which is useful for enforcing a migration or fencing off something that should not exist yet.
+- [`oncePerPackage`](/docs/rules/once-per-package) — assert that a given rule is applied exactly once per package, which catches the case where overlapping config silently applies something twice.
+
+## Node 20 is now the minimum
+
+The published packages now declare `engines.node: ">=20"`, up from `>=18`.
+
+This is less of a change than it looks. The runtime dependencies of these packages already required Node 20 or newer — `find-up`, `glob`, `globby` and `yargs` had all moved on — so the previous `>=18` was overstating what actually worked. This makes the metadata honest rather than dropping anything that was functioning.
+
+## Smaller improvements
+
+- [`consistentVersions`](/docs/rules/consistent-versions) understands protocols such as `catalog:`.
+- `requireDependency` accepts `undefined` for a version as another way to remove an entry.
+- [`fileContents`](/docs/rules/file-contents) has clearer `message` and `longMessage` output.
+- When you are on pnpm, `mrl` now suggests the right command for your package manager instead of a generic one.
+
+## Fixes
+
+- `CachingHost` had a symlink follow limit that never actually decremented, because the recursive call used a post-decrement. The `Exhausted symlink follows` guard could never fire, so a symlink cycle recursed until the stack overflowed instead of raising a clean error.
+- `getWorkspacePackageDirs` silently ignored negated workspace patterns. If you used `["packages/*", "!packages/excluded"]` in a yarn or npm workspace, the exclusion did nothing, because each pattern was expanded on its own and a `!`-prefixed pattern matched nothing rather than excluding anything. Positive and negative patterns are now expanded separately. This only affected non-pnpm monorepos.
+
+## Dependencies and security
+
+A large number of dependencies moved in this release, most of it clearing security advisories across the tree. The notable ones for consumers are the runtime dependencies of the published packages: `glob` to 13, `globby` to 16, `zod` to 4.5, plus `semver`, `yargs` and `jest-diff`.
+
+## Feedback
+
+As always, please tell us what is and is not working, either in [GitHub Discussions](https://github.com/monorepolint/monorepolint/discussions) or by [opening an issue](https://github.com/monorepolint/monorepolint/issues/new/choose).

--- a/packages/docs/blog/2026-09-01-060.md
+++ b/packages/docs/blog/2026-09-01-060.md
@@ -11,7 +11,7 @@ v0.6.0 is out, and this time there are real release notes.
 
 When we shipped v0.5.0 I apologized for not having any and promised that changesets would fix that going forward. This post is that promise coming due.
 
-The short version: you can now tell MRL what _shouldn't_ exist, not just what should. Large monorepos get a proper answer for organizing rules. And the minimum supported Node version is now 20.
+The short version: you can now tell MRL what _shouldn't_ exist, not just what should. Large monorepos get a proper answer for organizing rules. The minimum supported Node version is now 20. And there are a handful of breaking changes worth reading before you upgrade.
 
 <!-- truncate -->
 
@@ -34,34 +34,42 @@ export default {
   rules: [
     // Delete a file if it exists
     fileContents({
-      file: "unwanted-config.json",
-      template: REMOVE,
+      options: {
+        file: "unwanted-config.json",
+        template: REMOVE,
+      },
     }),
 
     // Drop a script, keep managing the others
     packageScript({
-      scripts: {
-        "outdated-script": REMOVE,
-        build: "tsc",
+      options: {
+        scripts: {
+          "outdated-script": REMOVE,
+          build: "tsc",
+        },
       },
     }),
 
     // Remove a dependency, from any dependency type
     requireDependency({
-      dependencies: {
-        lodash: REMOVE,
-        react: "^18.0.0",
-      },
-      devDependencies: {
-        "old-test-lib": REMOVE,
+      options: {
+        dependencies: {
+          lodash: REMOVE,
+          react: "^18.0.0",
+        },
+        devDependencies: {
+          "old-test-lib": REMOVE,
+        },
       },
     }),
 
     // Remove a top-level package.json field
     packageEntry({
-      entries: {
-        browser: REMOVE,
-        main: "./index.js",
+      options: {
+        entries: {
+          browser: REMOVE,
+          main: "./index.js",
+        },
       },
     }),
   ],
@@ -70,35 +78,91 @@ export default {
 
 Four rules understand it — [`fileContents`](/docs/rules/file-contents), [`packageScript`](/docs/rules/package-script), [`requireDependency`](/docs/rules/require-dependency) and [`packageEntry`](/docs/rules/package-entry) — and it means the same thing in all of them. It works with `--fix`, and it is safe to leave in place: removing something that is already gone is not an error, so you can keep the rule around to stop the thing coming back.
 
+`packageScript` goes a little further than the example above. As well as `"script": REMOVE`, you can put `REMOVE` inside an `options` array to say "absent is an acceptable state", and use `fixValue: REMOVE` to have `--fix` delete the script.
+
 ## Archetypes for large monorepos
 
 Once a monorepo gets big enough, rule configuration becomes its own maintenance problem. You end up with long chains of `includePackages` and `excludePackages` patterns that are hard to read and easy to get subtly wrong.
 
-[`@monorepolint/archetypes`](/docs/guides/archetypes) is a new package that takes a different approach. Instead of describing which packages to skip, you describe the _kinds_ of packages you have — a published TypeScript library, a test-only package, a sample app — and the rules that belong to each. Every package matches exactly one archetype, and you can make it an error for a package to match none.
+[`@monorepolint/archetypes`](/docs/guides/archetypes) is a new package that takes a different approach. Instead of describing which packages to skip, you describe the _kinds_ of packages you have — a published TypeScript library, a test-only package, a sample app — and the rules that belong to each. Every package matches exactly one archetype, and you can make it an error for a package to match none. It also exports `ifTrue`, for conditionally including a rule inside an archetype.
+
+Note that this is a separate install — it does not come along with the `monorepolint` package:
+
+```
+npm install --save-dev @monorepolint/archetypes
+```
 
 ## Config as a function
 
 Config files can now be a factory function, and that function can be `async`. This makes it much easier to build configuration up programmatically or to pull in something you need to await first.
 
-The `ConfigFn` type was also fixed to actually reflect that it can be async.
+The factory receives a context, so it can also report its own problems with `context.addError(...)` — if it does, MRL stops with `failed to process the config file` rather than continuing with a half-built config.
+
+The `ConfigFn` type was also fixed to actually reflect that it can be async, and is now exported from `@monorepolint/config`.
 
 ## Two new rules
 
-- [`forceError`](/docs/rules/force-error) — deliberately fail for a set of packages, which is useful for enforcing a migration or fencing off something that should not exist yet.
-- [`oncePerPackage`](/docs/rules/once-per-package) — assert that a given rule is applied exactly once per package, which catches the case where overlapping config silently applies something twice.
+- [`forceError`](/docs/rules/force-error) — deliberately fail for a set of packages, which is useful for enforcing a migration or fencing off something that should not exist yet. Takes an optional `customMessage`.
+- [`oncePerPackage`](/docs/rules/once-per-package) — assert that a given rule is applied exactly once per package, which catches the case where overlapping config silently applies something twice. Requires a `singletonKey` (a string or symbol) identifying what is being counted, and takes an optional `customMessage`.
 
-## Node 20 is now the minimum
+## Breaking changes
+
+The Node bump is the headline one, but there are several others. None of them should need more than a small edit, and most repos will hit none of them.
+
+### Node 20 is now the minimum
 
 The published packages now declare `engines.node: ">=20"`, up from `>=18`.
 
-This is less of a change than it looks. The runtime dependencies of these packages already required Node 20 or newer — `find-up`, `glob`, `globby` and `yargs` had all moved on — so the previous `>=18` was overstating what actually worked. This makes the metadata honest rather than dropping anything that was functioning.
+This is less of a change than it looks. The runtime dependencies of these packages already required Node 20 or newer — `find-up`, `globby` and `yargs` had all moved on — so the previous `>=18` was overstating what actually worked. This makes the metadata honest rather than dropping anything that was functioning.
+
+### Rule options are now validated by zod, not runtypes
+
+Internally, every rule's options schema moved from `runtypes` to [zod](https://zod.dev) 4. Your config does not change, but **the error you get for an invalid rule option now comes from zod and reads differently**. If you have anything parsing or matching against MRL's validation output, it will need updating.
+
+This also means `@monorepolint/rules` now brings `zod` into your dependency tree instead of `runtypes`.
+
+### `standardTsconfig`'s `template` must be an object
+
+It previously accepted a string as well. A string never really worked — it was spread into the generated config downstream — so this turns something that silently produced nonsense into an up-front validation error. If you were passing a string, pass the parsed object instead.
+
+### `fileContents` generators must return `REMOVE`, not `undefined`, to delete
+
+If you had a generator function that returned `undefined` to mean "delete this file", it now reports an unfixable error instead. Return `REMOVE`:
+
+```ts
+// before
+template: () => shouldExist ? contents : undefined,
+
+// after
+template: () => shouldExist ? contents : REMOVE,
+```
+
+On the plus side, a generator that _throws_ is now contained: you get an unfixable lint error for that file rather than the whole run falling over.
+
+### `consistentVersions` is stricter about version strings it cannot parse
+
+This is the one most likely to produce new errors on an existing config.
+
+When you give [`consistentVersions`](/docs/rules/consistent-versions) an **array** of accepted versions, a dependency whose actual version string does not parse as semver is now an error. Previously it was silently skipped.
+
+In practice this means things like `workspace:*`, `github:org/repo` or `link:../thing` will start failing where they used to pass. If that is intentional in your repo, add the protocol to the accepted list — array entries can be protocol strings as well as ranges.
+
+The single-string form is unaffected.
+
+### `CachingHost.readFile` throws instead of returning `undefined`
+
+Reading a missing file now throws an ENOENT error, matching `SimpleHost`. This affects runs with `MRL_CACHING_HOST=true`, and anyone using `CachingHost` from `@monorepolint/utils` directly.
+
+### New CLI exit code 101
+
+`mrl check` now exits **101** when something goes wrong internally — an unloadable or missing config, or a rule that throws. Previously these escaped as an unhandled rejection. A failed check is still exit **100**, and success is still **0**. If your CI branches on exit codes, add the new one.
 
 ## Smaller improvements
 
 - [`consistentVersions`](/docs/rules/consistent-versions) understands protocols such as `catalog:`.
-- `requireDependency` accepts `undefined` for a version as another way to remove an entry.
-- [`fileContents`](/docs/rules/file-contents) has clearer `message` and `longMessage` output.
+- [`fileContents`](/docs/rules/file-contents) has clearer `message` and `longMessage` output, and rejects file paths containing null bytes.
 - When you are on pnpm, `mrl` now suggests the right command for your package manager instead of a generic one.
+- `@monorepolint/core` exports `createWorkspaceContext`, for building a `WorkspaceContext` outside the CLI.
 
 ## Fixes
 
@@ -107,7 +171,7 @@ This is less of a change than it looks. The runtime dependencies of these packag
 
 ## Dependencies and security
 
-A large number of dependencies moved in this release, most of it clearing security advisories across the tree. The notable ones for consumers are the runtime dependencies of the published packages: `glob` to 13, `globby` to 16, `zod` to 4.5, plus `semver`, `yargs` and `jest-diff`.
+A large number of dependencies moved in this release, most of it clearing security advisories across the tree. The ones that reach consumers are the runtime dependencies of the published packages: `glob` to 13, `globby` to 16, plus `semver`, `yargs` and `jest-diff`.
 
 ## Feedback
 

--- a/packages/docs/blog/2026-09-01-060.md
+++ b/packages/docs/blog/2026-09-01-060.md
@@ -160,7 +160,6 @@ Reading a missing file now throws an ENOENT error, matching `SimpleHost`. This a
 ## Smaller improvements
 
 - [`consistentVersions`](/docs/rules/consistent-versions) understands protocols such as `catalog:`.
-- [`requireDependency`](/docs/rules/require-dependency) also accepts `undefined` as a version to remove an entry, which is how this worked before `REMOVE` existed. `REMOVE` is the clearer spelling and what we would reach for in new config, but the older form keeps working.
 - [`fileContents`](/docs/rules/file-contents) has clearer `message` and `longMessage` output, and rejects file paths containing null bytes.
 - When you are on pnpm, `mrl` now suggests the right command for your package manager instead of a generic one.
 - `@monorepolint/core` exports `createWorkspaceContext`, for building a `WorkspaceContext` outside the CLI.

--- a/packages/docs/blog/2026-09-01-060.md
+++ b/packages/docs/blog/2026-09-01-060.md
@@ -160,6 +160,7 @@ Reading a missing file now throws an ENOENT error, matching `SimpleHost`. This a
 ## Smaller improvements
 
 - [`consistentVersions`](/docs/rules/consistent-versions) understands protocols such as `catalog:`.
+- [`requireDependency`](/docs/rules/require-dependency) also accepts `undefined` as a version to remove an entry, which is how this worked before `REMOVE` existed. `REMOVE` is the clearer spelling and what we would reach for in new config, but the older form keeps working.
 - [`fileContents`](/docs/rules/file-contents) has clearer `message` and `longMessage` output, and rejects file paths containing null bytes.
 - When you are on pnpm, `mrl` now suggests the right command for your package manager instead of a generic one.
 - `@monorepolint/core` exports `createWorkspaceContext`, for building a `WorkspaceContext` outside the CLI.


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until v0.6.0 is actually published.** Merging to `main` triggers `.github/workflows/documentation.yml`, which deploys the site and would announce a release that does not exist yet.

Drafts the release blog post for v0.6.0.

v0.5.0's post apologised for having no release notes and said changesets would fix that going forward. This one is written from the 20 accumulated changesets rather than from memory, so it should actually deliver on that.

## Structure

Leads with the three things a user would notice first:

1. **`REMOVE`** — declarative cleanup across `fileContents`, `packageScript`, `requireDependency` and `packageEntry`. Framed as the gap it closes: MRL was already good at asserting things exist, and had no answer for getting rid of them.
2. **`@monorepolint/archetypes`** — the answer for large monorepos, contrasted against long `includePackages` / `excludePackages` chains.
3. **Node 20** — stated plainly as metadata catching up rather than support being dropped, since `find-up`, `glob`, `globby` and `yargs` already required it.

Then config-as-a-function, the two new rules (`forceError`, `oncePerPackage`), smaller improvements, the two behavioural fixes, and the dependency/security work.

The two fixes are described in terms of what a user would have observed — a symlink cycle blowing the stack instead of erroring cleanly, and `!`-prefixed workspace patterns silently doing nothing on yarn/npm — rather than in terms of the code that changed.

## Verification

Built the docs site locally:

- Renders at `/blog/0.6.0/`
- **All eight documentation links resolve** to real generated pages (checked each against `build/`)
- Includes a `<!-- truncate -->` marker, so it does not add to the existing warning about the two older posts lacking one

The only build warnings are pre-existing: the untruncated older posts, the `authors.yml` notice that applies to all three posts, and the broken anchor on `consistent-versions`.

## Revised after a full diff audit

The first draft was written from the changesets. A follow-up audit of the whole diff since `monorepolint@0.5.0` (124 commits, 184 files) found **six breaking changes no changeset mentions**, plus three errors in the draft. All are now addressed.

### Errors fixed in the draft

- **The `REMOVE` code sample did not run.** Rules take `{ options: { ... } }` — `createRuleFactory` reads `ruleEntry.options` — and the sample omitted the wrapper, so every rule received `undefined` options. The mistake came verbatim from `.changeset/radical-remove-symbol.md`; the docs have it right.
- **Dropped the `requireDependency` / `undefined` claim.** It is currently a silent no-op — filed as #496.
- **Removed `glob` from the Node 20 justification.** `glob@13.0.6` declares `18 || 20 || >=22`. `find-up`, `globby` and `yargs` do require 20, so the argument holds without it.

### New "Breaking changes" section

Seven entries with migration notes:

| Change | Why it matters |
|---|---|
| `runtypes` → `zod` 4 for option validation | Every validation error message changes shape. The draft framed zod as a version bump; it is a replacement. |
| `standardTsconfig.template` must be an object | A string used to load and now fails validation |
| `fileContents` generators need `REMOVE`, not `undefined` | Silently loses the delete, gains a permanent error |
| `consistentVersions` array form errors on unparseable versions | **Most likely source of new errors on upgrade** — `workspace:`, `github:`, `link:` values now fail where they were skipped |
| `CachingHost.readFile` throws ENOENT | Affects `MRL_CACHING_HOST=true` and direct users |
| New CLI exit code **101** | CI scripts branching on exit codes |
| Node `>=20` | Already covered |

### Also added

`oncePerPackage`'s required `singletonKey` and `forceError`'s `customMessage` — without which neither rule could actually be used from the post; that `@monorepolint/archetypes` is a separate install and exports `ifTrue`; that a config factory can report errors via `context.addError`; `packageScript`'s fuller `REMOVE` syntax; and `createWorkspaceContext`.

## Worth a look before this ships

- **#496** — the `requireDependency` regression. `.changeset/small-llamas-pretend.md` is queued for this release and describes something that does not work, so it needs resolving either way.
- **#497** — the archetypes guide's example config would fail to load, and this post links to that page as the entry point for a headline feature.
- **The byline is copied from the v0.5.0 post**, including `author_title: Software Architect @ Palantir`. Worth confirming that is still accurate.
- If you would rather be able to merge this safely ahead of the release, adding `draft: true` to the frontmatter excludes it from production builds. Left off deliberately, since the stated plan is to hold the PR.
