### PR TITLE
Fix broken examples in archetypes and fileContents docs

### DIFF
--- a/.changeset/tidy-plants-relax.md
+++ b/.changeset/tidy-plants-relax.md
@@ -1,0 +1,5 @@
+---
+"@monorepolint/docs": patch
+---
+
+Fix archetypes guide and fileContents examples in docs

--- a/packages/docs/docs/guides/archetypes.md
+++ b/packages/docs/docs/guides/archetypes.md
@@ -1,6 +1,6 @@
 # Archetypes and Large Monorepos
 
-After a monorepo grows in complexity, managing your rules can be quite complex. You may have a lot of different types of packages which can make applying consistent rules across classes of packages especially challenging. For that we build `@osdk/archetypes`.
+After a monorepo grows in complexity, managing your rules can be quite complex. You may have a lot of different types of packages which can make applying consistent rules across classes of packages especially challenging. For that we build `@monorepolint/archetypes`.
 
 Instead of creating complex rule chains with include/exclude patterns that are hard to follow, you can instead define different archetypes and know that your rules are only applied consistently and only once per package.
 
@@ -19,6 +19,7 @@ Additionally, we will configure our archetypes builder to error if it finds any 
 
 ```ts
 import { archetypes, ifTrue } from "@monorepolint/archetypes";
+import { packageEntry, standardTsconfig } from "@monorepolint/rules";
 
 interface MyRules {
   react?: boolean;
@@ -26,64 +27,72 @@ interface MyRules {
   jsOnly?: boolean;
 }
 
-export default archetypes<MyRules>(
-  (shared, rules) => {
-    return [
-      ...ifTrue(
-        !rules.jsOnly,
-        standardTsConfig({
-          template: {
-            compilerOptions: {
-              rootDir: "src",
-              outDir: "lib",
-              ...(rules.react
-                ? { jsx: "react" }
-                : {}),
+export default {
+  rules: archetypes<MyRules>(
+    (shared, rules) => {
+      return [
+        ...ifTrue(
+          !rules.jsOnly,
+          [
+            standardTsconfig({
+              ...shared,
+              options: {
+                template: {
+                  compilerOptions: {
+                    rootDir: "src",
+                    outDir: "lib",
+                    ...(rules.react
+                      ? { jsx: "react" }
+                      : {}),
+                  },
+                  include: ["./src/**/*"],
+                },
+              },
+            }),
+          ],
+        ),
+        packageEntry({
+          ...shared,
+          options: {
+            entries: {
+              private: !!rules.private,
             },
-            include: ["./src/**/*"],
           },
         }),
-      ),
-      packageEntry({
-        ...shared,
-        options: {
-          entries: {
-            private: !!rules.private,
-          },
-        },
-      }),
-    ];
-  },
-  { unmatched: "error" },
-)
-  .addArchetype(
-    "tests",
-    ["@mine/tests.*"],
-    {
-      private: true,
+      ];
     },
+    { unmatched: "error" },
   )
-  .addArchetype(
-    "benchmarks",
-    ["@mine/benchmarks.*"],
-    {
-      private: true,
-      jsOnly: true,
-    },
-  )
-  .addArchetype(
-    "sample apps",
-    ["@mine/examples.*"],
-    {
-      private: true,
-      react: true,
-    },
-  )
-  .addArchetype(
-    "libraries",
-    ["@mine/a", "@mine/b"],
-    {},
-  );
+    .addArchetype(
+      "tests",
+      ["@mine/tests.*"],
+      {
+        private: true,
+      },
+    )
+    .addArchetype(
+      "benchmarks",
+      ["@mine/benchmarks.*"],
+      {
+        private: true,
+        jsOnly: true,
+      },
+    )
+    .addArchetype(
+      "sample apps",
+      ["@mine/examples.*"],
+      {
+        private: true,
+        react: true,
+      },
+    )
+    .addArchetype(
+      "libraries",
+      ["@mine/a", "@mine/b"],
+      {},
+    )
+    .buildRules(),
+};
 ```
 
 ### Using fallback configuration
@@ -95,20 +104,22 @@ const rulesForUnmatchedPackages: {
   private: true;
 };
 
-export default archetypes<MyRules>(
-  (shared, rules) => {
-    return [
-      // ... our rules here
-    ];
-  },
-  {
-    unmatched: rulesForUnmatchedPackages,
-  },
-).addArchetype(
-  "libraries",
-  ["@mine/a", "@mine/b"],
-  {},
-);
+export default {
+  rules: archetypes<MyRules>(
+    (shared, rules) => {
+      return [
+        // ... our rules here
+      ];
+    },
+    {
+      unmatched: rulesForUnmatchedPackages,
+    },
+  ).addArchetype(
+    "libraries",
+    ["@mine/a", "@mine/b"],
+    {},
+  ).buildRules(),
+};
 ```
 
 ### Catching packages declared as two different archetypes
@@ -138,18 +149,20 @@ export default [
 Here, `@mine/react-lib` will be triggered by both rules creating a hard to debug situation. But with archetypes, we get a clean error:
 
 ```ts
-export default archetypes<MyRules>(
-  myCustomRuleFunc,
-  { unmatched: rulesForUnmatchedPackages },
-).addArchetype(
-  "uses react",
-  ["@mine/docs", "@mine/example", "@mine/react-*"],
-  { react: true },
-).addArchetype(
-  "public packages",
-  ["@mine/react-lib"],
-  {},
-);
+export default {
+  rules: archetypes<MyRules>(
+    myCustomRuleFunc,
+    { unmatched: rulesForUnmatchedPackages },
+  ).addArchetype(
+    "uses react",
+    ["@mine/docs", "@mine/example", "@mine/react-*"],
+    { react: true },
+  ).addArchetype(
+    "public packages",
+    ["@mine/react-lib"],
+    {},
+  ).buildRules(),
+};
 ```
 
-With this configuration, you would get an error that `@osdk/react-lib` was already included in the archetype `"uses react"` allowing you to fix your conflict much quicker.
+With this configuration, you would get an error that `@mine/react-lib` was already included in the archetype `"uses react"` allowing you to fix your conflict much quicker.

--- a/packages/docs/docs/rules/file-contents.md
+++ b/packages/docs/docs/rules/file-contents.md
@@ -72,11 +72,11 @@ export default {
         template: REMOVE,
       },
     }),
-    // Delete file (legacy syntax - still supported)
+    // Delete file
     fileContents({
       options: {
         file: "old-config.js",
-        template: undefined, // delete file
+        template: REMOVE,
       },
     }),
     // Generator example


### PR DESCRIPTION
Closes #497

## Summary

Two live docs pages contained example config that does not work against current code.

### 1. `docs/guides/archetypes.md`

Every example exported the `archetypes(...)` builder directly as the config default export. `resolveConfig` reads `config.rules` (`packages/core/src/resolveConfig.ts:14`), and `ArchetypesImpl` only exposes `buildRules(): RuleModule[]` (`packages/archetypes/src/ArchetypesImpl.ts:33`), not a `rules` property — so `config.rules` was `undefined` and `mrl check` would throw. Corrected shape:

```ts
export default {
  rules: archetypes<MyRules>(
    (shared, rules) => { ... },
    { unmatched: "error" },
  )
    .addArchetype("libraries", ["@mine/a", "@mine/b"], {})
    .buildRules(),
};
```

While empirically verifying this shape (see below), the first example's rule-provider callback turned out to have three more bugs that would also prevent it from loading or working correctly, so I fixed those too since they're in the same code block:

- `standardTsConfig` (wrong casing, and never imported) → `standardTsconfig`, now imported from `@monorepolint/rules`
- `template`/`include` passed as siblings to `standardTsconfig(...)` instead of nested under `options`, and the archetype's `shared` (`includePackages`) was never spread in — the rule would've applied to every package in the workspace, not just the archetype's packages
- `...ifTrue(!rules.jsOnly, standardTsconfig({...}))` spread a single `RuleModule` (not an array) — `ifTrue`'s non-array overload returns the value as-is, so the spread throws `TypeError: ... is not iterable` at config-load time. Fixed by wrapping in `[...]`.

Also replaced leftover `@osdk/archetypes` / `@osdk/react-lib` references (from another repo) with `@monorepolint/archetypes` / `@mine/react-lib`. Grepped the rest of `packages/docs/docs/` for `@osdk` — no other occurrences.

### 2. `docs/rules/file-contents.md`

The "legacy syntax - still supported" example used `template: undefined` to delete a file. `Options` is a 3-member zod union (`packages/rules/src/fileContents.ts:16-42`) and `{ file, template: undefined }` fails all three members — confirmed by actually running it (see below). Replaced with `template: REMOVE` and dropped the "still supported" claim. `REMOVE` was already imported in that example's import block. Checked the rest of the page for the related `generator` returning `undefined` idiom — no remaining occurrences; all generator examples already return `string` or `REMOVE`.

## How I verified

- Built the workspace (`pnpm turbo build --force`), then `pnpm pack`'d `@monorepolint/{config,utils,core,rules,archetypes,cli}` (pnpm pack rewrites `workspace:^` to real semver ranges) and installed them as `file:` deps into a throwaway two-package pnpm workspace in the scratchpad, outside this repo.
- Ran `mrl check` against that fixture with the corrected archetypes config (matching the doc's first example): confirmed it loads, correctly reports missing `tsconfig.json`/`private` entries, and `mrl check --fix` converges to a clean `mrl check`.
- Reproduced the original bug first: the unmodified `template: undefined` example fails validation with a `ZodError` (`invalid_union`, all three members rejected), reproducing the issue's report exactly. Confirmed `template: REMOVE` passes cleanly.
- `CI=1 pnpm turbo check --force` → 29/29 successful.
- `CI=1 pnpm --filter @monorepolint/docs run build-docs` → succeeds with only the three pre-existing warnings (blog truncation markers on two old posts, `authors.yml` notice, broken anchor on `consistent-versions`) — no new warnings.
- `CI=1 pnpm exec changeset status` → runs clean, `@monorepolint/docs` picked up.

## Scope

Did not touch `packages/docs/blog/` (v0.6.0 post ships separately in #495) or any source in `packages/rules`/`packages/core`/`packages/archetypes` — this is docs-only.