### PR TITLE
fix: requireDependency again removes an entry when the version is undefined

### DIFF
--- a/.changeset/olive-frogs-arrive.md
+++ b/.changeset/olive-frogs-arrive.md
@@ -1,0 +1,5 @@
+---
+"@monorepolint/rules": patch
+---
+
+Fix `requireDependency` ignoring `undefined` as a version. Setting a dependency's version to `undefined` removes it, as it did before the `REMOVE` symbol was introduced — it is now treated as an alias for `REMOVE` rather than being silently dropped.

--- a/packages/rules/src/__tests__/requireDependency.spec.ts
+++ b/packages/rules/src/__tests__/requireDependency.spec.ts
@@ -164,6 +164,70 @@ describe("requireDependency", () => {
     expect(contents).toEqual(CORRECT_OUTPUT);
   });
 
+  describe("undefined as an alias for REMOVE", () => {
+    // `undefined` predates the REMOVE symbol. It is still accepted so that
+    // configs written before REMOVE existed keep working.
+
+    function runWith(
+      version: string | typeof REMOVE | undefined,
+      { fix }: { fix: boolean },
+    ) {
+      const { addFile, readFile, workspaceContext } = makeWorkspace({ fix });
+      addFile("./package.json", PACKAGE_ROOT);
+      addFile(
+        "./packages/a/package.json",
+        jsonToString({ dependencies: { lodash: "^4.17.21" } }),
+      );
+
+      const context = workspaceContext.createChildContext(
+        path.resolve(workspaceContext.packageDir, "./packages/a"),
+      );
+      const addErrorSpy = vi.spyOn(context, "addError");
+      requireDependency({ options: { dependencies: { lodash: version } } })
+        .check(context);
+
+      return {
+        errors: addErrorSpy.mock.calls.length,
+        dependencies: JSON.parse(readFile("./packages/a/package.json")).dependencies,
+      };
+    }
+
+    it("removes the dependency when fixing", () => {
+      const result = runWith(undefined, { fix: true });
+      expect(result.dependencies).toEqual({});
+    });
+
+    it("reports an error when not fixing", () => {
+      const result = runWith(undefined, { fix: false });
+      expect(result.errors).toBe(1);
+      expect(result.dependencies).toEqual({ lodash: "^4.17.21" });
+    });
+
+    it("behaves identically to REMOVE", () => {
+      expect(runWith(undefined, { fix: true })).toEqual(
+        runWith(REMOVE, { fix: true }),
+      );
+      expect(runWith(undefined, { fix: false })).toEqual(
+        runWith(REMOVE, { fix: false }),
+      );
+    });
+
+    it("is a no-op when the dependency is already absent", () => {
+      const { addFile, workspaceContext } = makeWorkspace({ fix: true });
+      addFile("./package.json", PACKAGE_ROOT);
+      addFile("./packages/a/package.json", jsonToString({ dependencies: {} }));
+
+      const context = workspaceContext.createChildContext(
+        path.resolve(workspaceContext.packageDir, "./packages/a"),
+      );
+      const addErrorSpy = vi.spyOn(context, "addError");
+      requireDependency({ options: { dependencies: { lodash: undefined } } })
+        .check(context);
+
+      expect(addErrorSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe("Missing package.json handling", () => {
     it("handles gracefully when package.json does not exist", () => {
       const { workspaceContext } = makeWorkspace({ fix: false });

--- a/packages/rules/src/requireDependency.ts
+++ b/packages/rules/src/requireDependency.ts
@@ -63,12 +63,14 @@ export const requireDependency = createRuleFactory({
         return;
       }
 
-      // Separate additions from removals upfront
+      // Separate additions from removals upfront.
+      // `undefined` is an alias for REMOVE, kept for configs written before
+      // REMOVE existed.
       const dependenciesToAdd = Object.entries(expectedEntries).filter(
         ([, version]) => version !== REMOVE && version !== undefined,
       );
       const dependenciesToRemove = Object.entries(expectedEntries).filter(
-        ([, version]) => version === REMOVE,
+        ([, version]) => version === REMOVE || version === undefined,
       );
 
       // Handle missing dependency block


### PR DESCRIPTION
Restores `requireDependency`'s `undefined`-means-remove behavior. Closes #496.

## What broke

Setting a dependency's version to `undefined` has meant "remove this dependency" since #276 (2025-01-22). It shipped working in `0.6.0-alpha.3`, `.4` and `.5`.

The `REMOVE` work in #392 (2025-08-29) replaced the old fixer branch:

```js
if (version === undefined) { delete input[type][dep]; }
```

with a split into `dependenciesToAdd` / `dependenciesToRemove`. `undefined` is explicitly excluded from the add list and isn't `REMOVE`, so it matched neither list and was silently dropped. It has been broken in `0.6.0-alpha.6` since 2025-11-07 — **longer than it ever worked**.

## Why nobody noticed

The failure is completely silent. The options schema still permits `undefined` (that value union carries `.optional()`), so the config validates, `check` reports no error, and `--fix` does nothing. The dependency just stays.

Side-by-side on the same package, same rule, same `--fix` run:

```
REMOVE     -> errors: 1 | deps after fix: {}
undefined  -> errors: 0 | deps after fix: {"lodash":"^4.17.21"}
```

There was no test covering it — the spec exercised `REMOVE` thoroughly and never `undefined`.

## The fix

One line. `undefined` joins `REMOVE` in the removal filter:

```js
const dependenciesToRemove = Object.entries(expectedEntries).filter(
  ([, version]) => version === REMOVE || version === undefined,
);
```

The removal loop only destructures `[dep]` and never reads the version, so nothing else needed to change.

## Tests

Four new tests in a dedicated describe block:

| Test | Fails without the fix? |
|---|---|
| removes the dependency when fixing | yes |
| reports an error when not fixing | yes |
| behaves identically to `REMOVE` | yes |
| no-op when the dependency is already absent | no — correctly passes either way |

I verified this by reverting the one-line change and re-running: 3 failed / 13 passed. With the fix: 16 passed. The fourth test passing both ways is correct — doing nothing is the right answer when there's nothing to remove — but worth stating so the table isn't mistaken for a weak test.

## Verification

- `turbo check --force` — 29/29 tasks
- `requireDependency.spec.ts` — 16/16, up from 12

## Note on the release notes

`.changeset/small-llamas-pretend.md` ("Feature: requireDependency now allows undefined for versions to remove the entry") is queued for 0.6.0 and is now accurate again, so it can stay as-is.

The v0.6.0 blog post (#495) had this claim removed while the behavior was broken. It should go back in once this merges — I'll follow up on that branch.
