### PR TITLE
Drop undefined-as-remove from requireDependency, keep REMOVE

### DIFF
--- a/.changeset/small-llamas-pretend.md
+++ b/.changeset/small-llamas-pretend.md
@@ -1,5 +1,0 @@
----
-"@monorepolint/rules": patch
----
-
-Feature: requireDependency now allows undefined for versions to remove the entry

--- a/packages/rules/src/__tests__/requireDependency.spec.ts
+++ b/packages/rules/src/__tests__/requireDependency.spec.ts
@@ -401,6 +401,24 @@ describe("requireDependency", () => {
       ).not.toThrow();
     });
 
+    it("should reject undefined as a version", () => {
+      // Use REMOVE to drop a dependency. `undefined` is rejected rather than
+      // accepted-and-ignored, so a config that means to remove something fails
+      // loudly instead of silently doing nothing.
+      const ruleModule = requireDependency({ options: {} });
+
+      for (
+        const type of [
+          "dependencies",
+          "devDependencies",
+          "peerDependencies",
+          "optionalDependencies",
+        ]
+      ) {
+        expect(() => ruleModule.validateOptions({ [type]: { react: undefined } })).toThrow();
+      }
+    });
+
     it("should reject invalid options", () => {
       const ruleModule = requireDependency({ options: {} });
 

--- a/packages/rules/src/requireDependency.ts
+++ b/packages/rules/src/requireDependency.ts
@@ -19,28 +19,28 @@ const Options = z.object({
     z.union([
       z.string(),
       ZodRemove,
-    ]).optional(),
+    ]),
   ).optional(),
   devDependencies: z.record(
     z.string(),
     z.union([
       z.string(),
       ZodRemove,
-    ]).optional(),
+    ]),
   ).optional(),
   peerDependencies: z.record(
     z.string(),
     z.union([
       z.string(),
       ZodRemove,
-    ]).optional(),
+    ]),
   ).optional(),
   optionalDependencies: z.record(
     z.string(),
     z.union([
       z.string(),
       ZodRemove,
-    ]).optional(),
+    ]),
   ).optional(),
 }).partial();
 


### PR DESCRIPTION
Replaces #499, which restored this behavior. Closes #496.

## Why drop it instead of fixing it

`undefined` as a version meaning "remove this dependency" was added in #276 on **2025-01-22 — six months after 0.5.0 shipped**. It exists only inside the 0.6.0 development window:

| | |
|---|---|
| Added | #276, 2025-01-22 |
| Worked in | `0.6.0-alpha.3`, `.4`, `.5` |
| Silently broken by | #392 (the `REMOVE` work), 2025-08-29 |
| Broken in | `0.6.0-alpha.6`, since 2025-11-07 |

At 0.5.0 the schema was `r.Dictionary(r.String)` — `undefined` wasn't even accepted. So **no stable release has ever had this**, and since 0.6.0 hasn't shipped, dropping it now means it never existed publicly. There's no deprecation cycle to run and nothing to announce.

That makes this a better outcome than restoring it. 0.6.0 ships **one** obvious way to remove something rather than two spellings we'd maintain forever, starting from a release where nobody depends on the second. `REMOVE` is documented, tested across four rules, and reads better at a call site than a bare `undefined`.

## What changed

The runtime filters on `main` already act only on `REMOVE`, so the substantive change is to the **options schema**.

Each value union carried `.optional()`:

```js
z.union([z.string(), ZodRemove]).optional(),   // ← removed
```

That let `undefined` validate and then fall through *both* the add and remove filters — accepted, ignored, no error, dependency untouched. Removing it makes `undefined` fail at validation instead:

```
{ lodash: undefined }    REJECTED
{ lodash: "^4" }         ACCEPTED
{ lodash: SYMBOL }       ACCEPTED
no dependencies key      ACCEPTED
```

The **outer** `.optional()` on each record is kept, so omitting a dependency block entirely is still fine.

This matters beyond tidiness: the trap wasn't that `undefined` stopped working, it was that it kept *validating*. Anyone writing `undefined` on the reasonable assumption that it means "no value, remove it" got silence. Failing loudly is the difference between finding out and never finding out — including for the alpha users whose configs are silently no-oping today.

## Also

Deleted `.changeset/small-llamas-pretend.md` ("Feature: requireDependency now allows undefined for versions to remove the entry"). It was queued for the 0.6.0 release notes and would have shipped a claim about behavior that no longer exists.

## Tests

Added one asserting `undefined` is rejected across all four dependency types. **Verified it fails against the loose schema and passes against the tightened one** — reverted the schema change, saw `1 failed | 12 passed`, restored it, saw `13 passed`.

## Verification

- `turbo check --force` — 29/29 tasks
- `requireDependency.spec.ts` — 13/13

## Follow-up

The v0.6.0 blog post (#495) currently mentions `undefined` as an accepted spelling. I'll drop that line from the post once this merges, so the release notes describe only `REMOVE`.
