### PR TITLE
chore(config): remove the unused chalk dependency

### DIFF
--- a/.changeset/eager-moons-visit.md
+++ b/.changeset/eager-moons-visit.md
@@ -1,0 +1,5 @@
+---
+"@monorepolint/config": patch
+---
+
+Removed the unused `chalk` dependency. Nothing in the package imported it; the real consumers are `@monorepolint/cli` and `@monorepolint/core`.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@monorepolint/utils": "workspace:^",
-    "chalk": "^5.6.2",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,9 +217,6 @@ importers:
       '@monorepolint/utils':
         specifier: workspace:^
         version: link:../utils
-      chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1


### PR DESCRIPTION
`packages/config` declared `chalk` but nothing in its source imported it.

```
$ grep -rn "chalk" packages/config/src --include="*.ts"
  NO USAGES
```

The real consumers are `@monorepolint/cli` (`src/index.ts`) and `@monorepolint/core` (`src/PackageContext.ts`), both of which keep it. The only remaining mention anywhere in the package is a historical line in its `CHANGELOG.md`.

## Checked before removing

Monorepolint lints itself, so a hand-removal can be undone by the next `monorepolint check --fix` if a rule expects the dependency. `packages/internal-mrl-config/src/monorepolint.config.ts` has no `chalk` reference and no `requireDependency`/`consistentVersions` rule covering it, so this sticks. The green `check-mrl` task confirms it.

## Changeset

`@monorepolint/config` is published, so removing an entry from its `dependencies` changes what consumers resolve and gets a changeset. Removing a dependency that nothing imports cannot change runtime behavior.

## Verification

- `turbo check --force` — 29/29 tasks
- `chalk@5.6.2` still resolves in the lockfile for `cli` and `core`

Found while researching the deferred chalk 6 upgrade (#501). Pulling it into v0.6.0 since it is unrelated to the Node 22 question that blocks the version bump.
